### PR TITLE
Fix some linting issues + add CI linting

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,34 @@
+# Lint the project using cpplint
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  cpplint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            cuda: "11.2"
+    env:
+      build_dir: "build"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Also install the linter.
+    - name: Install cpplint
+      run: pip3 install cpplint && echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    # Configure cmake, including tests to make sure they are linted.
+    - name: Configure cmake
+      run: cmake . -B ${{ env.build_dir }} -DALLOW_LINT_ONLY=ON
+
+    # Run the linter.
+    - name: Lint
+      run: cmake --build . --target all_lint --verbose -j `nproc` 
+      working-directory: ${{ env.build_dir }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,83 +112,96 @@ MACRO (download_freetype)
     endif()
 ENDMACRO()
 
-project(flamegpu2_visualiser CUDA CXX)
+# Set the project name, but do not specify languages immediately so we can have lint only builds.
+project(flamegpu2_visualiser)
 
-include(FindOpenGL)
-if (NOT TARGET OpenGL::GL)
-    message(FATAL_ERROR "OpenGL is required for building")
-endif ()
-download_glm()
-if (UNIX)
-    # Linux users need to install it via their package manager
-    # e.g. sudo apt install cmake libsdl2-dev g++
-    find_package(SDL2)
-    if (NOT SDL2_FOUND)
-      message(FATAL_ERROR "sdl2 is required for building, install it via your package manager.\n"
-                          "e.g. sudo apt install libsdl2-dev")
-    endif ()    
-    find_package(GLEW)
-    if (NOT GLEW_FOUND)
-      message(FATAL_ERROR "glew is required for building, install it via your package manager.\n"
-                          "e.g. sudo apt install libglew-dev")
-    endif ()
-    find_package(Freetype)
-    if (NOT FREETYPE_FOUND)
-      message(FATAL_ERROR "freetype is required for building, install it via your package manager.\n"
-                          "e.g. sudo apt install libfreetype-dev")
-    endif ()
-    if (NOT TARGET OpenGL::GLU)
-      message(FATAL_ERROR "GLU is required for building, install it via your package manager.\n"
-                          "e.g. sudo apt install libglu1-mesa-dev")
-    endif ()
-    find_package(Fontconfig)
-    if (NOT Fontconfig_FOUND)
-        message(FATAL_ERROR "Fontconfig is required for visualisation, install it via your package manager.\n"
-                          "e.g. sudo apt install libfontconfig1-dev")
+# Option to group CMake generated projects into folders in supported IDEs
+option(CMAKE_USE_FOLDERS "Enable folder grouping of projects in IDEs." ON)
+mark_as_advanced(CMAKE_USE_FOLDERS)
+
+
+# Add a new cmake option, to allow lint_only configurations.
+option(ALLOW_LINT_ONLY "Allow the project to be configured for lint-only builds" OFF)
+mark_as_advanced(ALLOW_LINT_ONLY)
+
+find_file(CPPLINT NAMES cpplint cpplint.exe)
+if(CPPLINT)
+
+    if(NOT TARGET all_lint)
+        add_custom_target(all_lint)
+        set_target_properties(all_lint PROPERTIES EXCLUDE_FROM_ALL TRUE)
     endif()
+    # Define a function to add a lint target.
+    function(new_linter_target NAME SRC)
+        # Don't lint external files
+        list(FILTER SRC EXCLUDE REGEX "^${FLAMEGPU_ROOT}/externals/.*")
+
+        LIST(APPEND CPPLINT_ARGS "")
+            
+        # Specify output format for msvc highlighting
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            LIST(APPEND CPPLINT_ARGS "--output" "vs7")
+        endif()
+        # Set the --root argument if included as a sub project.
+        if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+            file(RELATIVE_PATH LINT_ROOT ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+            LIST(APPEND CPPLINT_ARGS "--root=${LINT_ROOT}")
+        endif()
+
+
+        # Add the lint_ target
+        add_custom_target(
+            "lint_${PROJECT_NAME}"
+            COMMAND ${CPPLINT} ${CPPLINT_ARGS}
+            ${SRC}
+        )
+
+        # Don't trigger this target on ALL_BUILD or Visual Studio 'Rebuild Solution'
+        set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        # set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE #This breaks all_lint in visual studio
+        # Add the custom target as a dependency of the global lint target
+        if(TARGET all_lint)
+            add_dependencies(all_lint lint_${NAME})
+        endif()
+        # Put within Lint filter
+        # Put within Lint filter
+        if (CMAKE_USE_FOLDERS)
+            set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+            # set_property(TARGET "${PROJECT_NAME}" PROPERTY FOLDER "FLAMEGPU")
+            set_property(TARGET "lint_${PROJECT_NAME}" PROPERTY FOLDER "Lint")
+        endif ()
+    endfunction()
 else()
-    if (NOT TARGET OpenGL::GLU)
-      message(FATAL_ERROR "GLU is required for building")
-    endif ()
-    #sdl
-    download_sdl2()
-    set(SDL2_DIR ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
-    configure_file(cmake/sdl2/sdl2-config.cmake sdl2/sdl2-config.cmake)
-    find_package(SDL2 REQUIRED)
-    #glew
-    download_glew()
-    set(GLEW_DIR ${CMAKE_CURRENT_BINARY_DIR}/glew)
-    configure_file(cmake/glew/glew-config.cmake glew/glew-config.cmake)
-    find_package(GLEW REQUIRED)
-    #freetype    
-    download_freetype()
-    # Force disable zlib/libpng, to avoid linker errors if theyre pseudo found in system
-    set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB ON CACHE BOOL "" FORCE)
-    set(CMAKE_DISABLE_FIND_PACKAGE_LIBPNG ON CACHE BOOL "" FORCE)
-    set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz ON CACHE BOOL "" FORCE)
-    set(FT_WITH_HARFBUZZ OFF CACHE BOOL "" FORCE)
-    set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
-    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_ZLIB)
-    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_LIBPNG)
-    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz)
-    mark_as_advanced(FORCE SKIP_INSTALL_ALL)
-    mark_as_advanced(FORCE FT_WITH_BZIP2)
-    mark_as_advanced(FORCE FT_WITH_HARFBUZZ)
-    mark_as_advanced(FORCE FT_WITH_PNG)
-    mark_as_advanced(FORCE FT_WITH_ZLIB)
-    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/freetype-src
-                     ${CMAKE_CURRENT_BINARY_DIR}/freetype-build
-                     EXCLUDE_FROM_ALL
-                     )
-endif ()
+    # Don't create this message multiple times
+    message( 
+        " cpplint: NOT FOUND!\n"
+        " Lint projects will not be generated.\n"
+        " Please install cpplint as described on https://pypi.python.org/pypi/cpplint.\n"
+        " In most cases command 'pip install --user cpplint' should be sufficient.")
+    function(new_linter_target NAME SRC)
+    endfunction()
+endif()
 
 
-# GCC requires -lpthreads for std::thread
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads REQUIRED)
+# Check to see if CUDA is available.
+include(CheckLanguage)
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+    enable_language(C)
+    enable_language(CXX)
+    enable_language(CUDA)
+endif()
 
+# Check to see if OpenGL is available.
+include(FindOpenGL)
 
+# If CUDA was not found, or opengl was not found we cannot build, but can lint, otherwise tehre should be a fatal error
+set(LINT_ONLY_BUILD "OFF")
+if(ALLOW_LINT_ONLY AND CPPLINT AND (NOT OPENGL_FOUND OR NOT CMAKE_CUDA_COMPILER))
+    set(LINT_ONLY_BUILD "ON")
+endif()
+
+# Define the list of source files early, for lint-only configurations
 # Prepare list of include files
 SET(VISUALISER_INCLUDE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/FLAMEGPU_Visualisation.h
@@ -290,165 +303,223 @@ SET(VISUALISER_ALL
     ${VISUALISER_SRC}
 )
 
-
-# Use C++14 standard - std::make_unique is 14 not 11
-# Specify using C++14 standard
-if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
-    set(CMAKE_CXX_STANDARD_REQUIRED true)
-endif ()
-if (NOT UNIX)
-    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-endif ()
-# Define output
-add_library("${PROJECT_NAME}" STATIC ${VISUALISER_ALL})
-# Set up include dirs
-target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/glm-src)
-target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS})
-target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${GLEW_INCLUDE_DIRS})
-if (FREETYPE_FOUND) # Only use this if we aren't building it ourselves
-    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS})
-endif ()
-if(Fontconfig_FOUND)
-    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${Fontconfig_INCLUDE_DIRS})
-endif()
-target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/external")
-target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-# Enable fPIC for linux shared library linking
-set_property(TARGET "${PROJECT_NAME}" PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-# Add the targets we depend on (this does link and include)
-# This propagates to any project that uses this as a dependency
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_link_libraries("${PROJECT_NAME}" "legacy_stdio_definitions") # This won't be required if we rebuild freetype with newer than vs2013
+# Add the lint target.
+if(CPPLINT)
+    new_linter_target("${PROJECT_NAME}" "${VISUALISER_ALL}")
 endif()
 
-# If gcc, need to add flag for std::experimental::filesystem
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries("${PROJECT_NAME}" "-lstdc++fs")
-endif()
+if(LINT_ONLY_BUILD)
+    # All should include all_lint if lint only build.
+    set_target_properties(all_lint PROPERTIES EXCLUDE_FROM_ALL FALSE)
+    if (NOT CPPLINT)
+        message(FATAL_ERROR "Cpplint is required for lint-only builds.")
+    endif()
+    message(STATUS "Lint-only build configuraiton due to missing dependencies")
+    if (NOT OPENGL_FOUND)
+        message(STATUS "OpenGL is required for building")
+    endif ()
+    if (NOT CMAKE_CUDA_COMPILER)
+        message(STATUS "CUDA is required for building")
+    endif ()
+else()
+    if (NOT OPENGL_FOUND)
+        message(FATAL_ERROR "OpenGL is required for building")
+    endif ()
+    if (NOT CMAKE_CUDA_COMPILER)
+        message(FATAL_ERROR "CUDA is required for building")
+    endif ()
+    download_glm()
+    if (UNIX)
+        # Linux users need to install it via their package manager
+        # e.g. sudo apt install cmake libsdl2-dev g++
+        find_package(SDL2)
+        if (NOT SDL2_FOUND)
+        message(FATAL_ERROR "sdl2 is required for building, install it via your package manager.\n"
+                            "e.g. sudo apt install libsdl2-dev")
+        endif ()    
+        find_package(GLEW)
+        if (NOT GLEW_FOUND)
+        message(FATAL_ERROR "glew is required for building, install it via your package manager.\n"
+                            "e.g. sudo apt install libglew-dev")
+        endif ()
+        find_package(Freetype)
+        if (NOT FREETYPE_FOUND)
+        message(FATAL_ERROR "freetype is required for building, install it via your package manager.\n"
+                            "e.g. sudo apt install libfreetype-dev")
+        endif ()
+        if (NOT TARGET OpenGL::GLU)
+        message(FATAL_ERROR "GLU is required for building, install it via your package manager.\n"
+                            "e.g. sudo apt install libglu1-mesa-dev")
+        endif ()
+        find_package(Fontconfig)
+        if (NOT Fontconfig_FOUND)
+            message(FATAL_ERROR "Fontconfig is required for visualisation, install it via your package manager.\n"
+                            "e.g. sudo apt install libfontconfig1-dev")
+        endif()
+    else ()
+        if (NOT TARGET OpenGL::GLU)
+        message(FATAL_ERROR "GLU is required for building")
+        endif ()
+        #sdl
+        download_sdl2()
+        set(SDL2_DIR ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
+        configure_file(cmake/sdl2/sdl2-config.cmake sdl2/sdl2-config.cmake)
+        find_package(SDL2 REQUIRED)
+        #glew
+        download_glew()
+        set(GLEW_DIR ${CMAKE_CURRENT_BINARY_DIR}/glew)
+        configure_file(cmake/glew/glew-config.cmake glew/glew-config.cmake)
+        find_package(GLEW REQUIRED)
+        #freetype    
+        download_freetype()
+        # Force disable zlib/libpng, to avoid linker errors if theyre pseudo found in system
+        set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB ON CACHE BOOL "" FORCE)
+        set(CMAKE_DISABLE_FIND_PACKAGE_LIBPNG ON CACHE BOOL "" FORCE)
+        set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz ON CACHE BOOL "" FORCE)
+        set(FT_WITH_HARFBUZZ OFF CACHE BOOL "" FORCE)
+        set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
+        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_ZLIB)
+        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_LIBPNG)
+        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz)
+        mark_as_advanced(FORCE SKIP_INSTALL_ALL)
+        mark_as_advanced(FORCE FT_WITH_BZIP2)
+        mark_as_advanced(FORCE FT_WITH_HARFBUZZ)
+        mark_as_advanced(FORCE FT_WITH_PNG)
+        mark_as_advanced(FORCE FT_WITH_ZLIB)
+        add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/freetype-src
+                        ${CMAKE_CURRENT_BINARY_DIR}/freetype-build
+                        EXCLUDE_FROM_ALL
+                        )
+    endif ()
 
 
-# Strip trailiing whitespace from SDL2_Libraries for Ubuntu1604 / libsdl2-dev 2.0.4
-string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
-target_link_libraries("${PROJECT_NAME}" "${SDL2_LIBRARIES}")
+    # GCC requires -lpthreads for std::thread
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads REQUIRED)
 
-target_link_libraries("${PROJECT_NAME}" "${GLEW_LIBRARIES}")
-target_link_libraries("${PROJECT_NAME}" freetype)
-target_link_libraries("${PROJECT_NAME}" OpenGL::GL)
-target_link_libraries("${PROJECT_NAME}" OpenGL::GLU)
-target_link_libraries("${PROJECT_NAME}" Threads::Threads)
-if(Fontconfig_FOUND)
-    target_link_libraries("${PROJECT_NAME}" Fontconfig::Fontconfig)
-endif()
-if(WIN32)
-target_link_libraries("${PROJECT_NAME}" "dwrite.lib")
-endif()
+    # Use C++14 standard - std::make_unique is 14 not 11
+    # Specify using C++14 standard
+    if (NOT DEFINED CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 14)
+        set(CMAKE_CXX_STANDARD_REQUIRED true)
+    endif ()
+    if (NOT UNIX)
+        add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    endif ()
+    # Define output
+    add_library("${PROJECT_NAME}" STATIC ${VISUALISER_ALL})
+    # Set up include dirs
+    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/glm-src)
+    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS})
+    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${GLEW_INCLUDE_DIRS})
+    if (FREETYPE_FOUND) # Only use this if we aren't building it ourselves
+        target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS})
+    endif ()
+    if(Fontconfig_FOUND)
+        target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${Fontconfig_INCLUDE_DIRS})
+    endif()
+    target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/external")
+    target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+    # Enable fPIC for linux shared library linking
+    set_property(TARGET "${PROJECT_NAME}" PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    # Add the targets we depend on (this does link and include)
+    # This propagates to any project that uses this as a dependency
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_link_libraries("${PROJECT_NAME}" "legacy_stdio_definitions") # This won't be required if we rebuild freetype with newer than vs2013
+    endif()
+
+    # If gcc, need to add flag for std::experimental::filesystem
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries("${PROJECT_NAME}" "-lstdc++fs")
+    endif()
 
 
-# Enable parallel compilation
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-endif ()
+    # Strip trailiing whitespace from SDL2_Libraries for Ubuntu1604 / libsdl2-dev 2.0.4
+    string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
+    target_link_libraries("${PROJECT_NAME}" "${SDL2_LIBRARIES}")
 
-# Resources
-# NOTE: The build step for resources embeds them as base64, this should not be used for large files.
-include(cmake/CMakeRC/CMakeRC.cmake)
-SET(RESOURCES_ALL
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_flat.frag
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_phong.frag
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/default.vert
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/text.frag
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/color.vert
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/color_noshade.frag
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/icosphere.obj
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/sphere.obj
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/cube.obj
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/teapot.obj
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/stuntplane.obj
+    target_link_libraries("${PROJECT_NAME}" "${GLEW_LIBRARIES}")
+    target_link_libraries("${PROJECT_NAME}" freetype)
+    target_link_libraries("${PROJECT_NAME}" OpenGL::GL)
+    target_link_libraries("${PROJECT_NAME}" OpenGL::GLU)
+    target_link_libraries("${PROJECT_NAME}" Threads::Threads)
+    if(Fontconfig_FOUND)
+        target_link_libraries("${PROJECT_NAME}" Fontconfig::Fontconfig)
+    endif()
+    if(WIN32)
+        target_link_libraries("${PROJECT_NAME}" "dwrite.lib")
+    endif()
+
+
+    # Enable parallel compilation
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+    endif ()
+
+    # Resources
+    # NOTE: The build step for resources embeds them as base64, this should not be used for large files.
+    include(cmake/CMakeRC/CMakeRC.cmake)
+    SET(RESOURCES_ALL
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_flat.frag
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_phong.frag
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/default.vert
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/text.frag
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/color.vert
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/color_noshade.frag
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/icosphere.obj
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/sphere.obj
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/cube.obj
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/teapot.obj
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/stuntplane.obj
 # Tdir: These shaders are setup to receive an appended rotation function
 # Tcolor: These shaders are setup to receive an appended color function
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/instanced_default_Tdir.vert
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/instanced_default_Tcolor_Tdir.vert
-    ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_flat_Tcolor.frag
-)
-cmrc_add_resource_library(resources ${RESOURCES_ALL})
-# Enable fPIC for resources (for wheel packaging)
-set_property(TARGET "resources" PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-message(STATUS "${PROJECT_NAME}")
-target_link_libraries("${PROJECT_NAME}" resources)
-
-# Setup Visual Studio (and eclipse) filters
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-#src/.h
-set(T_SRC "${VISUALISER_ALL}")
-list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
-list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX headers FILES ${T_SRC})
-#src/.cpp
-set(T_SRC "${VISUALISER_ALL}")
-list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
-list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX src FILES ${T_SRC})
-#./.h
-set(T_SRC "${VISUALISER_ALL}")
-list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
-list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX headers FILES ${T_SRC})
-#./.cpp
-set(T_SRC "${VISUALISER_ALL}")
-list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
-list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX src FILES ${T_SRC})
-
-# Stuff borrowed from FGPU2/common.cmake
-# Option to group CMake generated projects into folders in supported IDEs
-option(CMAKE_USE_FOLDERS "Enable folder grouping of projects in IDEs." ON)
-mark_as_advanced(CMAKE_USE_FOLDERS)
-# Define a function to add a lint target.
-find_file(CPPLINT NAMES cpplint cpplint.exe)
-if (CPPLINT)
-    # Add custom target for linting this
-    # Variable for linter arguments.
-    LIST(APPEND CPPLINT_ARGS "")
-
-    # Set the --root argument if included as a sub project.
-    if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-        file(RELATIVE_PATH LINT_ROOT ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-        LIST(APPEND CPPLINT_ARGS "--root=${LINT_ROOT}")
-    endif()
-        
-    # Specify output format for msvc highlighting
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        LIST(APPEND CPPLINT_ARGS "--output" "vs7")
-    endif()
-
-    # Add the lint_ target
-    add_custom_target(
-        "lint_${PROJECT_NAME}"
-        COMMAND ${CPPLINT} ${CPPLINT_ARGS}
-        ${VISUALISER_ALL}
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/instanced_default_Tdir.vert
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/instanced_default_Tcolor_Tdir.vert
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources/material_flat_Tcolor.frag
     )
-    # Don't trigger this target on ALL_BUILD or Visual Studio 'Rebuild Solution'
-    set_target_properties("lint_${PROJECT_NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
-    # set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE #This breaks all_lint in visual studio
-    # Add the custom target as a dependency of the global lint target
-    if (TARGET all_lint)
-        add_dependencies(all_lint lint_${PROJECT_NAME})
-    endif ()
-    # Put within Lint filter
-    if (CMAKE_USE_FOLDERS)
-      set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-      set_property(TARGET "${PROJECT_NAME}" PROPERTY FOLDER "FLAMEGPU")
-      set_property(TARGET "lint_${PROJECT_NAME}" PROPERTY FOLDER "Lint")
-      if (TARGET freetype)
-        set_property(TARGET "freetype" PROPERTY FOLDER "FLAMEGPU/Dependencies")
-        set_property(TARGET "resources" PROPERTY FOLDER "FLAMEGPU/Dependencies")
-      endif ()
-    endif ()
-endif ()
+    cmrc_add_resource_library(resources ${RESOURCES_ALL})
+    # Enable fPIC for resources (for wheel packaging)
+    set_property(TARGET "resources" PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+    message(STATUS "${PROJECT_NAME}")
+    target_link_libraries("${PROJECT_NAME}" resources)
+
+    # Setup Visual Studio (and eclipse) filters
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+    #src/.h
+    set(T_SRC "${VISUALISER_ALL}")
+    list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX headers FILES ${T_SRC})
+    #src/.cpp
+    set(T_SRC "${VISUALISER_ALL}")
+    list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX src FILES ${T_SRC})
+    #./.h
+    set(T_SRC "${VISUALISER_ALL}")
+    list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX headers FILES ${T_SRC})
+    #./.cpp
+    set(T_SRC "${VISUALISER_ALL}")
+    list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX src FILES ${T_SRC})
+
+    # Stuff borrowed from FGPU2/common.cmake
+
+    # Put freetype in a folder.
+    if (CMAKE_USE_FOLDERS)
+        set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+        if (TARGET freetype)
+            set_property(TARGET "freetype" PROPERTY FOLDER "FLAMEGPU/Dependencies")
+            set_property(TARGET "resources" PROPERTY FOLDER "FLAMEGPU/Dependencies")
+        endif()
+    endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 ## Introduction
 
 This repository contains the components for the FLAMEGPU2 visualiser. This provides the capability for FLAMEGPU2 models to display a real-time visualisation. This repository is automatically pulled in by [FLAMEGPU2](https://github.com/FLAMEGPU/FLAMEGPU2_dev) when the `VISUALISATION` option is enabled within the CMake configuration. It is unlikely to be useful independently.
+
+
+
+### Lint Only Configuration
+
+The project can be configured to allow linting without the need for CUDA or OpenGL to be available (i.e. CI). 
+
+To do this, set the `ALLOW_LINT_ONLY` CMake option to `ON`.

--- a/include/config/TexBufferConfig.h
+++ b/include/config/TexBufferConfig.h
@@ -8,8 +8,7 @@
  * Holds data identifying a requested texture buffer
  */
 struct TexBufferConfig {
-    enum Function
-    {
+    enum Function {
         /**
          * Agent location x/y/z
          */
@@ -53,7 +52,7 @@ struct TexBufferConfig {
         default: return "";
         }
     }
-    TexBufferConfig(const std::string& _agentVariableName = "")
+    explicit TexBufferConfig(const std::string& _agentVariableName = "")
         : agentVariableName(_agentVariableName) { }
     /**
      * Agent variable which maps to this buffer

--- a/src/Visualiser.cpp
+++ b/src/Visualiser.cpp
@@ -335,7 +335,7 @@ void Visualiser::render() {
             if (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
                 resizeWindow();
             break;
-        case SDL_KEYDOWN: 
+        case SDL_KEYDOWN:
             {
                 int x = 0;
                 int y = 0;
@@ -352,25 +352,25 @@ void Visualiser::render() {
             this->toggleMouseMode();
             break;
         case SDL_CONTROLLERDEVICEADDED:
-			this->addController(e.cdevice);
-			break;
-		case SDL_CONTROLLERDEVICEREMOVED:
-			this->removeController(e.cdevice);
-			break;
-		case SDL_CONTROLLERBUTTONDOWN:
-			this->handleControllerButton(e.cbutton);
-			break;
-		case SDL_CONTROLLERBUTTONUP:
-			this->handleControllerButton(e.cbutton);
-			break;
-		// case SDL_CONTROLLERAXISMOTION:
+            this->addController(e.cdevice);
+            break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            this->removeController(e.cdevice);
+            break;
+        case SDL_CONTROLLERBUTTONDOWN:
+            this->handleControllerButton(e.cbutton);
+            break;
+        case SDL_CONTROLLERBUTTONUP:
+            this->handleControllerButton(e.cbutton);
+            break;
+        // case SDL_CONTROLLERAXISMOTION:
             // Couldn't get this event to behave nicely in the past for some reason.
             // break;
         }
     }
     // Doesn't use the event class for some historical reason I (pth) don't remember.
     this->queryControllerAxis(frameTime);
-    //Update lighting
+    // Update lighting
     lighting->update();
     //  render
     BackBuffer::useStatic();
@@ -493,7 +493,7 @@ void Visualiser::updateAgentStateBuffer(const std::string &agent_name, const std
     //  Copy Data
     const auto& first_buff = as.core_texture_buffers.begin()->second;
     const unsigned int buff_size = first_buff ? first_buff->elementCount : 0;
-    if (buff_size >= buffLen) { // This may fail for a single frame occasionally
+    if (buff_size >= buffLen) {  // This may fail for a single frame occasionally
         for (const auto &_ext_tb : ext_core_tex_buffers) {
             auto &ext_tb = _ext_tb.second;
             auto &int_tb = as.core_texture_buffers.at(_ext_tb.first);
@@ -512,8 +512,7 @@ void Visualiser::updateAgentStateBuffer(const std::string &agent_name, const std
 
 //  Items taken from sdl_exp
 bool Visualiser::init() {
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) != 0)
-    {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) != 0) {
         fprintf(stderr, "Unable to initialize SDL: %s", SDL_GetError());
         return false;
     }
@@ -651,18 +650,17 @@ void Visualiser::toggleFPSStatus() {
     if (!this->stepDisplay && fpsStatus == 1)
         fpsStatus = 0;
     // Set the appropriate display state
-    switch (fpsStatus)
-    {
-    case 0: // Hide all
+    switch (fpsStatus) {
+    case 0:  // Hide all
         if (this->stepDisplay)
             this->stepDisplay->setVisible(false);
-    case 1: // Hide fps/sps
+    case 1:  // Hide fps/sps
         if (this->fpsDisplay)
             this->fpsDisplay->setVisible(false);
         if (this->spsDisplay)
             this->spsDisplay->setVisible(false);
         break;
-    default: // Show all
+    default:  // Show all
         if (this->stepDisplay)
             this->stepDisplay->setVisible(true);
         if (this->fpsDisplay)
@@ -813,74 +811,69 @@ void Visualiser::setWindowTitle(const char *_windowTitle) {
 }
 
 // Game controller methods
-void Visualiser::addController(const SDL_ControllerDeviceEvent sdlEvent){
-	int device = sdlEvent.which;
-	// If it is the 0th gamepad, proceed.
-	if (device == 0){
-		this->gamepad = SDL_GameControllerOpen(device);
-		this->joystick = SDL_GameControllerGetJoystick(gamepad);
-		this->joystickInstance = SDL_JoystickInstanceID(this->joystick);
-		this->gamepadConnected = true;
-	}
+void Visualiser::addController(const SDL_ControllerDeviceEvent sdlEvent) {
+    int device = sdlEvent.which;
+    // If it is the 0th gamepad, proceed.
+    if (device == 0) {
+        this->gamepad = SDL_GameControllerOpen(device);
+        this->joystick = SDL_GameControllerGetJoystick(gamepad);
+        this->joystickInstance = SDL_JoystickInstanceID(this->joystick);
+        this->gamepadConnected = true;
+    }
 }
-void Visualiser::removeController(const SDL_ControllerDeviceEvent sdlEvent){
-	if (this->gamepadConnected) {
-		this->gamepadConnected = false;
-		SDL_GameControllerClose(this->gamepad);
-		this->gamepad = 0;
-	}
+void Visualiser::removeController(const SDL_ControllerDeviceEvent sdlEvent) {
+    if (this->gamepadConnected) {
+        this->gamepadConnected = false;
+        SDL_GameControllerClose(this->gamepad);
+        this->gamepad = 0;
+    }
 }
 // @todo - handle continuous button states
-void Visualiser::handleControllerButton(const SDL_ControllerButtonEvent sdlEvent){
-	// If it is the correct controller
-	if (sdlEvent.which == this->joystickInstance){
-		// If it is being pressed down
-		if (sdlEvent.type == SDL_CONTROLLERBUTTONDOWN){
-			// Print the button being pressed.
-			switch (sdlEvent.button){
-			case SDL_CONTROLLER_BUTTON_A:
+void Visualiser::handleControllerButton(const SDL_ControllerButtonEvent sdlEvent) {
+    // If it is the correct controller
+    if (sdlEvent.which == this->joystickInstance) {
+        // If it is being pressed down
+        if (sdlEvent.type == SDL_CONTROLLERBUTTONDOWN) {
+            // Print the button being pressed.
+            switch (sdlEvent.button) {
+            case SDL_CONTROLLER_BUTTON_A:
                 break;
-			case SDL_CONTROLLER_BUTTON_B:
+            case SDL_CONTROLLER_BUTTON_B:
                 break;
-			case SDL_CONTROLLER_BUTTON_X:
-				// this->camera->resetLocation();
-				break;
-			case SDL_CONTROLLER_BUTTON_Y:
-				// this->camera->storeLocation();
-				break;
+            case SDL_CONTROLLER_BUTTON_X:
+                // this->camera->resetLocation();
+                break;
+            case SDL_CONTROLLER_BUTTON_Y:
+                // this->camera->storeLocation();
+                break;
             case SDL_CONTROLLER_BUTTON_BACK:
-                printf("SDL_CONTROLLER_BUTTON_BACK\n");
                 this->toggleFPSStatus();
-				break;
+                break;
             case SDL_CONTROLLER_BUTTON_GUIDE:
-                printf("SDL_CONTROLLER_BUTTON_GUIDE\n");
-				break;
+                break;
             case SDL_CONTROLLER_BUTTON_START:
-                if (this->pause_guard)
-                {
+                if (this->pause_guard) {
                     delete pause_guard;
                     pause_guard = nullptr;
-                }
-                else
-                {
+                } else {
                     pause_guard = new std::lock_guard<std::mutex>(render_buffer_mutex);
                     stepsPerSecond = 0.0f;
                 }
                 break;
             case SDL_CONTROLLER_BUTTON_LEFTSTICK:
-				break;
+                break;
             case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
-				break;
-			case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
-				break;
-			case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
-				break;
-			case SDL_CONTROLLER_BUTTON_DPAD_UP:
+                break;
+            case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+                break;
+            case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+                break;
+            case SDL_CONTROLLER_BUTTON_DPAD_UP:
                 this->toggleFullScreen();
                 break;
-			case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-				this->screenshot(true);
-				break;
+            case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+                this->screenshot(true);
+                break;
             case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
                 renderLines = !renderLines;
                 break;
@@ -888,32 +881,32 @@ void Visualiser::handleControllerButton(const SDL_ControllerButtonEvent sdlEvent
                 this->hud->reload();
                 break;
             case SDL_CONTROLLER_BUTTON_MAX:
-				break;
+                break;
             default:
-				break;
-			}
-		}
-		// else if (sdlEvent.type == SDL_CONTROLLERBUTTONUP){
-		// }
-	}
+                break;
+            }
+        }
+        // else if (sdlEvent.type == SDL_CONTROLLERBUTTONUP){
+        // }
+    }
 }
 // If there is a controllwer attached update all relevant values
-void Visualiser::queryControllerAxis(const unsigned int frameTime){
-	if (this->gamepadConnected){
-		// Load in all values
-		float leftX = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_LEFTX) / (float)SHRT_MAX;
-		float leftY = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_LEFTY) / (float)SHRT_MAX;
-		float rightX = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_RIGHTX) / (float)SHRT_MAX;
-		float rightY = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_RIGHTY) / (float)SHRT_MAX;
-		float triggerL = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_TRIGGERLEFT) / (float)SHRT_MAX;
-		float triggerR = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) / (float)SHRT_MAX;
-		float buttonA = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_A);
-		float buttonB = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_B);
+void Visualiser::queryControllerAxis(const unsigned int frameTime) {
+    if (this->gamepadConnected) {
+        // Load in all values
+        float leftX = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_LEFTX) / static_cast<float>(SHRT_MAX);
+        float leftY = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_LEFTY) / static_cast<float>(SHRT_MAX);
+        float rightX = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_RIGHTX) / static_cast<float>(SHRT_MAX);
+        float rightY = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_RIGHTY) / static_cast<float>(SHRT_MAX);
+        float triggerL = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_TRIGGERLEFT) / static_cast<float>(SHRT_MAX);
+        float triggerR = SDL_GameControllerGetAxis(this->gamepad, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) / static_cast<float>(SHRT_MAX);
+        float buttonA = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_A);
+        float buttonB = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_B);
         float leftShoulder = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_LEFTSHOULDER);
         float rightShoulder = SDL_GameControllerGetButton(this->gamepad, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER);
 
         float speed = modelConfig.cameraSpeed[0];
-		if (triggerL > AXIS_TRIGGER_DEAD_ZONE) {
+        if (triggerL > AXIS_TRIGGER_DEAD_ZONE) {
             speed /= modelConfig.cameraSpeed[1];
         }
         if (triggerR > AXIS_TRIGGER_DEAD_ZONE) {
@@ -921,32 +914,32 @@ void Visualiser::queryControllerAxis(const unsigned int frameTime){
         }
         const float distance = speed * static_cast<float>(frameTime);
 
-		// Strafe on left X axis
-		if (abs(leftX) > AXIS_LEFT_DEAD_ZONE){
+        // Strafe on left X axis
+        if (abs(leftX) > AXIS_LEFT_DEAD_ZONE) {
             this->camera->strafe(leftX * distance);
         }
-		// Move on left Y axis
-		if (abs(leftY) > AXIS_LEFT_DEAD_ZONE){
+        // Move on left Y axis
+        if (abs(leftY) > AXIS_LEFT_DEAD_ZONE) {
             this->camera->move(-leftY * distance);
         }
 
-		float thetaInc = 0.0;
-		float phiInc = 0.0;
-		// Look using right stick
-		if (abs(rightX) > AXIS_RIGHT_DEAD_ZONE){
-			thetaInc = rightX * AXIS_DELTA_THETA;
-		}
-		if (abs(rightY) > AXIS_RIGHT_DEAD_ZONE){
-			phiInc = rightY * AXIS_DELTA_PHI;
-		}
-		// Avoid Drift
-		if (abs(rightX) > AXIS_TURN_THRESHOLD && abs(rightY) > AXIS_TURN_THRESHOLD){
-			this->camera->turn(thetaInc, phiInc);
-		}
-		if (buttonA){
+        float thetaInc = 0.0;
+        float phiInc = 0.0;
+        // Look using right stick
+        if (abs(rightX) > AXIS_RIGHT_DEAD_ZONE) {
+            thetaInc = rightX * AXIS_DELTA_THETA;
+        }
+        if (abs(rightY) > AXIS_RIGHT_DEAD_ZONE) {
+            phiInc = rightY * AXIS_DELTA_PHI;
+        }
+        // Avoid Drift
+        if (abs(rightX) > AXIS_TURN_THRESHOLD && abs(rightY) > AXIS_TURN_THRESHOLD) {
+            this->camera->turn(thetaInc, phiInc);
+        }
+        if (buttonA) {
             this->camera->ascend(distance);
         }
-		if (buttonB){
+        if (buttonB) {
             this->camera->ascend(-distance);
         }
         if (leftShoulder) {

--- a/src/Visualiser.h
+++ b/src/Visualiser.h
@@ -1,32 +1,34 @@
 #ifndef SRC_VISUALISER_H_
 #define SRC_VISUALISER_H_
 
+#include <SDL.h>
+
 #include <atomic>
-#include <string>
-#include <unordered_map>
+#include <list>
 #include <memory>
 #include <mutex>
-#include <utility>
+#include <string>
 #include <thread>
-#include <list>
-
-#include <SDL.h>
+#include <unordered_map>
+#include <utility>
+#include <map>
 #undef main  // SDL breaks the regular main entry point, this fixes
 #define GLM_FORCE_NO_CTOR_INIT
 #include <glm/glm.hpp>
 
-#include "interface/Viewport.h"
-#include "camera/NoClipCamera.h"
+#include "Draw.h"
+#include "Entity.h"
 #include "HUD.h"
 #include "Text.h"
-
-#include "config/ModelConfig.h"
+#include "camera/NoClipCamera.h"
 #include "config/AgentStateConfig.h"
 #include "config/TexBufferConfig.h"
+#include "config/ModelConfig.h"
+#include "interface/Viewport.h"
 #include "Draw.h"
 #include "Entity.h"
 
-template<typename T>
+template <typename T>
 struct CUDATextureBuffer;
 
 class LightsBuffer;
@@ -37,10 +39,7 @@ class LightsBuffer;
 class Visualiser : public ViewportExt {
     typedef std::pair<std::string, std::string> NamePair;
     struct NamePairHash {
-        size_t operator()(const NamePair& k) const {
-            return std::hash < std::string>()(k.first) ^
-                (std::hash < std::string>()(k.second) << 1);
-        }
+        size_t operator()(const NamePair &k) const { return std::hash<std::string>()(k.first) ^ (std::hash<std::string>()(k.second) << 1); }
     };
     /**
      * This structs holds the information required for rendering agents for a single agent-state
@@ -60,7 +59,7 @@ class Visualiser : public ViewportExt {
     };
 
  public:
-    explicit Visualiser(const ModelConfig& modelcfg);
+    explicit Visualiser(const ModelConfig &modelcfg);
     ~Visualiser();
     /**
      * Starts the render loop running
@@ -111,93 +110,92 @@ class Visualiser : public ViewportExt {
         const std::map<TexBufferConfig::Function, TexBufferConfig>& _core_tex_buffers, const std::multimap<TexBufferConfig::Function, CustomTexBufferConfig>& _tex_buffers);
 
  private:
-     void run();
-     /**
+    void run();
+    /**
      * A single pass of the render loop
      * Also handles keyboard/mouse IO
      */
-     void render();
-     /**
+    void render();
+    /**
      * Renders contents of agentStates map
      */
-     void renderAgentStates();
-     /**
+    void renderAgentStates();
+    /**
      * Toggles the window between borderless fullscreen and windowed states
      */
-     void toggleFullScreen();
-     /**
+    void toggleFullScreen();
+    /**
      * @return True if the window is currently full screen
      */
-     bool isFullscreen() const;
-     /**
+    bool isFullscreen() const;
+    /**
      * Toggles whether the mouse is hidden and returned relative to the window
      */
-     void toggleMouseMode();
-     /**
+    void toggleMouseMode();
+    /**
      * Toggles the status of FPS logged to the HUD
      */
-     void toggleFPSStatus();
-     /**
+    void toggleFPSStatus();
+    /**
      * Toggles whether Multi-Sample Anti-Aliasing should be used or not
      * @param state The desired MSAA state
      * @note Unless blocked by the active Scene the F10 key toggles MSAA at runtime
      */
-     void setMSAA(bool state);
-     /**
+    void setMSAA(bool state);
+    /**
      * Provides key handling for none KEY_DOWN events of utility keys (ESC, F11, F10, F5, etc)
      * @param keycode The keypress detected
      * @param x The horizontal mouse position at the time of the KEY_DOWN event
      * @param y The vertical mouse position at the time of the KEY_DOWN event
      * @note Unsure whether the mouse position is relative to the window
      */
-     void handleKeypress(SDL_Keycode keycode, int x, int y);
-     /**
+    void handleKeypress(SDL_Keycode keycode, int x, int y);
+    /**
      * Moves the camera according to the motion of the mouse (whilst the mouse is attatched to the window via toggleMouseMode())
      * @param x The horizontal distance moved
      * @param y The vertical distance moved
      * @note This is called within the render loop
      */
-     void handleMouseMove(int x, int y);
-     /**
+    void handleMouseMove(int x, int y);
+    /**
      * Initialises SDL and creates the window
      * @return Returns true on success
      * @note This method doesn't begin the render loop, use run() for that
      */
-     bool init();
-     /**
-      * Util method which handles deallocating all objects which contains GLbuffers, shaders etc
-      */
-     void deallocateGLObjects();
-     /**
+    bool init();
+    /**
+     * Util method which handles deallocating all objects which contains GLbuffers, shaders etc
+     */
+    void deallocateGLObjects();
+    /**
      * Provides destruction of the object, deletes child objects, removes the GL context, closes the window and calls SDL_quit()
      */
-     void close();
-     /**
+    void close();
+    /**
      * Simple implementation of an FPS counter
      * @note This is called within the render loop
      */
-     void updateFPS();
-     /**
+    void updateFPS();
+    /**
      * Updates the viewport and projection matrix
      * This should be called after window resize events, or simply if the viewport needs generating
      */
-     void resizeWindow();
-
+    void resizeWindow();
 
     void addController(const SDL_ControllerDeviceEvent sdlEvent);
-	void removeController(const SDL_ControllerDeviceEvent sdlEvent);
-	void handleControllerButton(const SDL_ControllerButtonEvent sdlEvent);
-	void handleControllerAxis(const SDL_ControllerAxisEvent sdlEvent);
+    void removeController(const SDL_ControllerDeviceEvent sdlEvent);
+    void handleControllerButton(const SDL_ControllerButtonEvent sdlEvent);
+    void handleControllerAxis(const SDL_ControllerAxisEvent sdlEvent);
     void queryControllerAxis(const unsigned int frameTime);
     void screenshot();
     void screenshot(const bool verbose);
 
- public :
-        /**
+ public:
+    /**
      * Returns the window's current width
      * @note This does not account for fullscreen window size
      */
-        unsigned int getWindowWidth() const override;
+    unsigned int getWindowWidth() const override;
     /**
      * Returns the window's current height
      * @note This does not account for fullscreen window size
@@ -208,11 +206,11 @@ class Visualiser : public ViewportExt {
      * @note This does not account for fullscreen window size
      */
     glm::uvec2 getWindowDims() const override;
-    const glm::mat4 * getProjectionMatPtr() const override;
+    const glm::mat4 *getProjectionMatPtr() const override;
     glm::mat4 getProjectionMat() const override;
     std::shared_ptr<const Camera> getCamera() const override;
     std::weak_ptr<HUD> getHUD() override;
-    const char * getWindowTitle() const override;
+    const char *getWindowTitle() const override;
     void setWindowTitle(const char *windowTitle) override;
     /**
      * Returns the mutex
@@ -227,7 +225,7 @@ class Visualiser : public ViewportExt {
     void setStepCount(const unsigned int &stepCount);
 
  private:
-    SDL_Window* window;
+    SDL_Window *window;
     SDL_Rect windowedBounds;
     SDL_GLContext context;
     /**
@@ -258,7 +256,7 @@ class Visualiser : public ViewportExt {
     /**
      * Current title of the visualisation window
      */
-    const char* windowTitle;
+    const char *windowTitle;
     /**
      * Current dimensions of the window (does not account for fullscreen size)
      */
@@ -337,10 +335,10 @@ class Visualiser : public ViewportExt {
     std::lock_guard<std::mutex> *pause_guard = nullptr;
 
     // Controller stuff
-	SDL_GameController *gamepad;
-	SDL_Joystick *joystick;
-	SDL_JoystickID joystickInstance;
-	bool gamepadConnected;
+    SDL_GameController *gamepad;
+    SDL_Joystick *joystick;
+    SDL_JoystickID joystickInstance;
+    bool gamepadConnected;
 };
 
 #endif  // SRC_VISUALISER_H_

--- a/src/config/ModelConfig.cpp
+++ b/src/config/ModelConfig.cpp
@@ -1,35 +1,26 @@
 #include "config/ModelConfig.h"
 
 #include <cstring>
-ModelConfig::StaticModel::StaticModel()
-    : path("")
-    , texture("")
-    , scale{-1, 0, 0}
-    , location{0, 0, 0}
-    , rotation{1, 0, 0, 0} { }
-ModelConfig::ModelConfig(const char* _windowTitle)
-    : windowTitle(nullptr)
-    , windowDimensions{1280, 720}
-    , clearColor{0, 0, 0}
-    , fpsVisible(true)
-    , fpsColor{1, 1, 1}
-    , cameraLocation{1.5f, 1.5f, 1.5f}
-    , cameraTarget{0, 0, 0}
-    , cameraSpeed{0.05f, 5}
-    , nearFarClip{0.05f, 5000}
-    , stepVisible(true)
-    , beginPaused(false) {
+ModelConfig::StaticModel::StaticModel() : path(""), texture(""), scale{-1, 0, 0}, location{0, 0, 0}, rotation{1, 0, 0, 0} {}
+ModelConfig::ModelConfig(const char *_windowTitle)
+    : windowTitle(nullptr),
+      windowDimensions{1280, 720},
+      clearColor{0, 0, 0},
+      fpsVisible(true),
+      fpsColor{1, 1, 1},
+      cameraLocation{1.5f, 1.5f, 1.5f},
+      cameraTarget{0, 0, 0},
+      cameraSpeed{0.05f, 5},
+      nearFarClip{0.05f, 5000},
+      stepVisible(true),
+      beginPaused(false) {
     setString(&windowTitle, _windowTitle);
 }
 ModelConfig::~ModelConfig() {
-    if (windowTitle)
-        free(const_cast<char*>(windowTitle));
+    if (windowTitle) free(const_cast<char *>(windowTitle));
 }
 
-ModelConfig::ModelConfig(const ModelConfig &other)
-    : windowTitle(nullptr) {
-    *this = other;
-}
+ModelConfig::ModelConfig(const ModelConfig &other) : windowTitle(nullptr) { *this = other; }
 ModelConfig &ModelConfig::operator=(const ModelConfig &other) {
     setString(&windowTitle, other.windowTitle);
     memcpy(windowDimensions, other.windowDimensions, sizeof(windowDimensions));
@@ -42,7 +33,7 @@ ModelConfig &ModelConfig::operator=(const ModelConfig &other) {
     memcpy(nearFarClip, other.nearFarClip, sizeof(nearFarClip));
     stepVisible = other.stepVisible;
     beginPaused = other.beginPaused;
-    //staticModels
-    //lines
+    // staticModels
+    // lines
     return *this;
 }

--- a/src/util/Resources.cpp
+++ b/src/util/Resources.cpp
@@ -54,9 +54,9 @@ namespace {
         }
         return result;
     }
-    inline unsigned long long hash_larson64(const char* s,
-        unsigned long long seed = 0) {
-        unsigned long long hash = seed;
+    inline uint64_t hash_larson64(const char* s,
+        uint64_t seed = 0) {
+        uint64_t hash = seed;
         while (*s) {
             hash = hash * 101 + *s++;
         }


### PR DESCRIPTION
Big changes to Cmake to allow lint configurations without GL or CUDA. 

If cmake is configured and CUDA or openGL are unavailable, but CPPLint is available,  a status message is produced stating that this is a lint only build. 

This also only lints teh contents of this repo. The visualisation only components of the main repo still avoid lint CI at present. It will be *much* more difficult to make that repo lint only... 

```
cmake .. 
-- Lint-only build configuraiton due to missing dependencies
-- CUDA is required for building
-- Configuring done
-- Generating done
```

Potentially it might be better to make lint only builds opt in? I.e. error if CUDA or OpenlGL not found, unless `-DLINT_ONLY=ON` or similar?

Testing: 
+ [x] Local Linux working with and without CUDA
+ [x] Local linux when included from FLAMEGPU2
+ [x] Linux CI without CUDA (or GL) 
+ [ ] Windows