### PR TITLE
Add Windows and Linux CI for building the visualiser library

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -1,0 +1,65 @@
+# Compile project on Ubuntu
+name: Ubuntu
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-visualiser:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          # 20.04 supports CUDA 11.0+ (gcc >= 5 && gcc <= 10). SM < 52 deprecated since 11.0
+          - os: ubuntu-20.04
+            cuda: "11.2"
+            cuda_arch: "52"
+            gcc: 10
+          # 18.04 supports CUDA 10.0+ (gcc <=8), 11.0+ (gcc<=9), 11.1+ (gcc<=10)
+          # - os: ubuntu-18.04
+          #   cuda: "10.0"
+          #   cuda_arch: "35"
+          #   gcc: 7
+    env:
+      build_dir: "build"
+      config: "Release"
+      build_tests: "ON"
+      Werror: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CUDA
+      env:
+        cuda: ${{ matrix.cuda }}
+      run: |
+        source ./scripts/actions/install_cuda_ubuntu.sh
+        if [[ $? -eq 0 ]]; then
+          # Set paths for subsequent steps, using ${CUDA_PATH}
+          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+          echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+          echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    # Specify the correct host compilers
+    - name: Install/Select gcc and g++ 
+      run: |
+        sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+        echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+
+    - name: Install visualisation dev dependencies
+      run: sudo apt-get install libsdl2-dev libglew-dev libfreetype-dev libdevil-dev libglu1-mesa-dev libfontconfig1-dev
+
+    - name: Configure cmake
+      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -Wno-error=dev
+
+    - name: Build Visualiser
+      run: cmake --build . --target all --verbose -j `nproc`
+      working-directory: ${{ env.build_dir }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,53 @@
+# Windows builds.
+name: Windows
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-visualiser:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          # Windows2019 & VS 2019 supports 10.1+
+          - os: windows-2019
+            cuda: "11.2.0"
+            visual_studio: "Visual Studio 16 2019"
+    env:
+      cuda_arch: "52"
+      build_dir: "build"
+      config: "Release"
+      build_tests: "OFF"
+      Werror: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CUDA
+      env: 
+        cuda: ${{ matrix.cuda }}
+        visual_studio: ${{ matrix.visual_studio }}
+      run: |
+        # Install CUDA via a powershell script
+        .\scripts\actions\install_cuda_windows.ps1
+        if ($?) {
+          # Set paths for subsequent steps, using $env:CUDA_PATH
+          echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+          echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        }
+      shell: powershell
+
+    - name: Configure CMake
+      id: configure
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -Wnoerror=dev
+      shell: bash
+
+    - name: Build Visualiser
+      run: cmake --build . --config ${{ env.config }} --target ALL_BUILD --verbose
+      working-directory: ${{ env.build_dir }}

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -1,0 +1,148 @@
+# @todo - better / more robust parsing of inputs from env vars.
+## -------------------
+## Constants
+## -------------------
+
+# @todo - apt repos/known supported versions?
+
+# @todo - GCC support matrix?
+
+# List of sub-packages to install.
+# @todo - pass this in from outside the script? 
+# @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
+
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too)
+CUDA_PACKAGES_IN=(
+    "command-line-tools"
+    "libraries-dev"
+)
+
+## -------------------
+## Bash functions
+## -------------------
+# returns 0 (true) if a >= b
+function version_ge() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+}
+# returns 0 (true) if a > b
+function version_gt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_ge $1 $2
+}
+# returns 0 (true) if a <= b
+function version_le() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+}
+# returns 0 (true) if a < b
+function version_lt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_le $1 $2
+}
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as $cuda.
+CUDA_VERSION_MAJOR_MINOR=${cuda}
+
+# Split the version.
+# We (might/probably) don't know PATCH at this point - it depends which version gets installed.
+CUDA_MAJOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f1)
+CUDA_MINOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f2)
+CUDA_PATCH=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f3)
+# use lsb_release to find the OS.
+UBUNTU_VERSION=$(lsb_release -sr)
+UBUNTU_VERSION="${UBUNTU_VERSION//.}"
+
+echo "CUDA_MAJOR: ${CUDA_MAJOR}"
+echo "CUDA_MINOR: ${CUDA_MINOR}"
+echo "CUDA_PATCH: ${CUDA_PATCH}"
+# echo "UBUNTU_NAME: ${UBUNTU_NAME}"
+echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
+
+# If we don't know the CUDA_MAJOR or MINOR, error.
+if [ -z "${CUDA_MAJOR}" ] ; then
+    echo "Error: Unknown CUDA Major version. Aborting."
+    exit 1
+fi
+if [ -z "${CUDA_MINOR}" ] ; then
+    echo "Error: Unknown CUDA Minor version. Aborting."
+    exit 1
+fi
+# If we don't know the Ubuntu version, error.
+if [ -z ${UBUNTU_VERSION} ]; then
+    echo "Error: Unknown Ubuntu version. Aborting."
+    exit 1
+fi
+
+
+## ---------------------------
+## GCC studio support check?
+## ---------------------------
+
+# @todo
+
+## -------------------------------
+## Select CUDA packages to install
+## -------------------------------
+CUDA_PACKAGES=""
+for package in "${CUDA_PACKAGES_IN[@]}"
+do : 
+    # @todo This is not perfect. Should probably provide a separate list for diff versions
+    # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
+    if [[ "${package}" == "nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="compiler"
+    elif [[ "${package}" == "compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="nvcc"
+    fi
+    # Build the full package name and append to the string.
+    CUDA_PACKAGES+=" cuda-${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+done
+echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
+
+## -----------------
+## Prepare to install
+## -----------------
+
+PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
+PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
+APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+
+echo "PIN_FILENAME ${PIN_FILENAME}"
+echo "PIN_URL ${PIN_URL}"
+echo "APT_KEY_URL ${APT_KEY_URL}"
+
+## -----------------
+## Install
+## -----------------
+echo "Adding CUDA Repository"
+wget ${PIN_URL}
+sudo mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
+sudo apt-key adv --fetch-keys ${APT_KEY_URL}
+sudo add-apt-repository "deb ${REPO_URL} /"
+sudo apt-get update
+
+echo "Installing CUDA packages ${CUDA_PACKAGES}"
+sudo apt-get -y install ${CUDA_PACKAGES}
+
+if [[ $? -ne 0 ]]; then
+    echo "CUDA Installation Error."
+    exit 1
+fi
+## -----------------
+## Set environment vars / vars to be propagated
+## -----------------
+
+CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
+echo "CUDA_PATH=${CUDA_PATH}"
+export CUDA_PATH=${CUDA_PATH}
+
+
+# Quick test. @temp
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+nvcc -V

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -1,0 +1,167 @@
+## -------------------
+## Constants
+## -------------------
+
+# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
+# From 11.0, the download URLs have changed as verisoning within CUDA has changed. 
+# The toolkit verison is separate from the individual versions of tools, i.e. toolkit 11.1.0 contains cudart 11.1.74, but CUPTI 11.1.69  
+$CUDA_KNOWN_URLS = @{
+    "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
+    "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
+    "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
+    "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
+    "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
+    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
+    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
+    "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
+    "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
+    "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
+}
+
+# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
+$VISUAL_STUDIO_MIN_CUDA = @{
+    "2019" = "10.1";
+    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
+    "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2
+}
+
+# cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
+# @todo - make this easier to vary per CUDA version.
+$CUDA_PACKAGES_IN = @(
+    "nvcc";
+    "visual_studio_integration";
+    "curand_dev";
+    "nvrtc_dev";
+    "cudart";
+)
+
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as env:cuda.
+$CUDA_VERSION_FULL = $env:cuda
+# Make sure CUDA_VERSION_FULL is set and valid, otherwise error.
+
+# Validate CUDA version, extracting components via regex
+$cuda_ver_matched = $CUDA_VERSION_FULL -match "^(?<major>[1-9][0-9]*)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$"
+if(-not $cuda_ver_matched){
+    Write-Output "Invalid CUDA version specified, <major>.<minor>.<patch> required. '$CUDA_VERSION_FULL'."
+    exit 1
+}
+$CUDA_MAJOR=$Matches.major
+$CUDA_MINOR=$Matches.minor
+$CUDA_PATCH=$Matches.patch
+
+## ---------------------------
+## Visual studio support check
+## ---------------------------
+# Exit if visual studio is too new for the cuda version.
+$VISUAL_STUDIO = $env:visual_studio.trim()
+if ($VISUAL_STUDIO.length -ge 4) {
+$VISUAL_STUDIO_YEAR = $VISUAL_STUDIO.Substring($VISUAL_STUDIO.Length-4)
+    if ($VISUAL_STUDIO_YEAR.length -eq 4 -and $VISUAL_STUDIO_MIN_CUDA.containsKey($VISUAL_STUDIO_YEAR)){
+        $MINIMUM_CUDA_VERSION = $VISUAL_STUDIO_MIN_CUDA[$VISUAL_STUDIO_YEAR]
+        if ([version]$CUDA_VERSION_FULL -lt [version]$MINIMUM_CUDA_VERSION) {
+            Write-Output "Error: Visual Studio $($VISUAL_STUDIO_YEAR) requires CUDA >= $($MINIMUM_CUDA_VERSION)"
+            exit 1
+        }
+    }
+} else {
+    Write-Output "Warning: Unknown Visual Studio Version. CUDA version may be insufficient."
+}
+
+## ------------------------------------------------
+## Select CUDA packages to install from environment
+## ------------------------------------------------
+
+$CUDA_PACKAGES = ""
+Foreach ($package in $CUDA_PACKAGES_IN) {
+    # Make sure the correct package name is used for nvcc.
+    if($package -eq "nvcc" -and [version]$CUDA_VERSION_FULL -lt [version]"9.1"){
+        $package="compiler"
+    } elseif($package -eq "compiler" -and [version]$CUDA_VERSION_FULL -ge [version]"9.1") {
+        $package="nvcc"
+    }
+    $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
+
+}
+echo "$($CUDA_PACKAGES)"
+## -----------------
+## Prepare download
+## -----------------
+
+# Select the download link if known, otherwise have a guess.
+$CUDA_REPO_PKG_REMOTE=""
+if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
+    $CUDA_REPO_PKG_REMOTE=$CUDA_KNOWN_URLS[$CUDA_VERSION_FULL]
+} else{
+    # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
+    Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
+    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+}
+$CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+
+
+## ------------
+## Install CUDA
+## ------------
+
+# Get CUDA network installer
+Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
+
+$downloaded = $false
+$download_attempt = 0
+$download_attempt_delay = 30
+$download_attempts_max = 5
+
+while (-not $downloaded) {
+    Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
+    $download_attempt++
+    # If download succeeded, break out the loop.
+    if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
+        Write-Output "Downloading Complete"
+        $downloaded=$true
+    } else {
+        # If downlaod failed, either wait and try again, or give up and error.
+        if ($download_attempt -le $download_attempts_max) {
+            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) (attempt $($download_attempt)/$($download_attempts_max)). Retrying."
+            # Sleep for a number of seconds.
+            Start-Sleep $download_attempt_delay
+        } else {
+            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) after $($download_attempts_max) attempts. Aborting."
+            # Abort the script.
+            exit 1
+        }
+    }
+}
+
+# Invoke silent install of CUDA (via network installer)
+Write-Output "Installing CUDA $($CUDA_VERSION_FULL). Subpackages $($CUDA_PACKAGES)"
+Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($CUDA_PACKAGES)"
+
+# Check the return status of the CUDA installer.
+if (!$?) {
+    Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
+    exit 1 
+}
+
+# Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
+$CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" 
+# Set environmental variables in this session
+$env:CUDA_PATH = "$($CUDA_PATH)"
+$env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
+Write-Output "CUDA_PATH $($CUDA_PATH)"
+Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
+
+# PATH needs updating elsewhere, anything in here won't persist.
+# Append $CUDA_PATH/bin to path.
+# Set CUDA_PATH as an environmental variable


### PR DESCRIPTION
Only builds the visualiser library itself, rather than also building FLAME GPU with visualisation enabled. 

Doesn't currently fail on Cmake configuration errors (see #59)
