### PR TITLE
Update GLM

### DIFF
--- a/cmake/glm/CMakeLists.txt.in
+++ b/cmake/glm/CMakeLists.txt.in
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 project(glm-download NONE)
 ExternalProject_Add(glm
-    URL              "https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.zip"
+    URL              "https://github.com/g-truc/glm/archive/66062497b104ca7c297321bd0e970869b1e6ece5.zip"
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/glm-src"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
This update is required for GLM to build with NVRTC.

I put in a required patch (and subsequent minor bugfix).

Hence required for the experimental rtc_glm branch in main repo.

Will merge when CI is happy.

Notably, since main dev of GLM has passed over maintenance to someone else. There hasn't been an official release in 13 months (prior there was a tagged release every ~6 months).