### PR TITLE
On windows, do not try to find libraries before dowloading them

### DIFF
--- a/cmake/dependencies/devil.cmake
+++ b/cmake/dependencies/devil.cmake
@@ -9,23 +9,20 @@ if(UNIX)
                         "e.g. sudo apt install libdevil-dev")
     endif()
 elseif(WIN32)
-    # On windows, if DevIL cannot be found, it is downloaded and CMake is told how to find it (via config mode)
-    find_package(DevIL QUIET NO_MODULE)
-    if(NOT DEVIL_FOUND)
-        # Declare source properties
-        FetchContent_Declare(
-            devil
-            URL "http://downloads.sourceforge.net/openil/DevIL-Windows-SDK-1.8.0.zip"
-        )
-        FetchContent_GetProperties(devil)
-        if(NOT devil_POPULATED)
-            # Download content
-            FetchContent_Populate(devil)
-            # Create a Cmake configuraiton file for devil (the download is not cmake aware)
-            set(DevIL_DIR ${devil_SOURCE_DIR})
-            configure_file(${CMAKE_CURRENT_LIST_DIR}/devil-config.cmake.in ${devil_SOURCE_DIR}/devil-config.cmake @ONLY)
-            # Find it again. Erroring if it cannot be found.
-            find_package(DevIL REQUIRED NO_MODULE)
-        endif()
+    # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
+    # Declare source properties
+    FetchContent_Declare(
+        devil
+        URL "http://downloads.sourceforge.net/openil/DevIL-Windows-SDK-1.8.0.zip"
+    )
+    FetchContent_GetProperties(devil)
+    if(NOT devil_POPULATED)
+        # Download content
+        FetchContent_Populate(devil)
+        # Create a Cmake configuraiton file for devil (the download is not cmake aware)
+        set(DevIL_DIR ${devil_SOURCE_DIR})
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/devil-config.cmake.in ${devil_SOURCE_DIR}/devil-config.cmake @ONLY)
+        # Find it again. Erroring if it cannot be found.
+        find_package(DevIL REQUIRED NO_MODULE)
     endif()
 endif()

--- a/cmake/dependencies/freetype.cmake
+++ b/cmake/dependencies/freetype.cmake
@@ -8,40 +8,37 @@ if(UNIX)
                             "e.g. sudo apt install libfreetype-dev")
     endif ()
 elseif(WIN32)
-    # On windows, if Freetype cannot be found, it is downloaded and CMake is told how to find it (via config mode)
-    find_package(Freetype QUIET)
-    if(NOT Freetype_FOUND)
-        # Declare source properties
-        # Alt official mirror: https://git.sv.nongnu.org/r/freetype/freetype2.git
-        FetchContent_Declare(
-            freetype
-            GIT_REPOSITORY    https://git.savannah.gnu.org/git/freetype/freetype2.git
-            GIT_TAG           tags/VER-2-10-1
-        )
+    # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
+    # Declare source properties
+    # Alt official mirror: https://git.sv.nongnu.org/r/freetype/freetype2.git
+    FetchContent_Declare(
+        freetype
+        GIT_REPOSITORY    https://git.savannah.gnu.org/git/freetype/freetype2.git
+        GIT_TAG           tags/VER-2-10-1
+    )
 
-        # Use variables to control freetype CMake options:
-        # Force disable zlib/libpng, to avoid linker errors if theyre pseudo found in system
-        set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB ON CACHE BOOL "" FORCE)
-        set(CMAKE_DISABLE_FIND_PACKAGE_LIBPNG ON CACHE BOOL "" FORCE)
-        set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz ON CACHE BOOL "" FORCE)
-        set(FT_WITH_HARFBUZZ OFF CACHE BOOL "" FORCE)
-        set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
-        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_ZLIB)
-        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_LIBPNG)
-        mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz)
-        mark_as_advanced(FORCE SKIP_INSTALL_ALL)
-        mark_as_advanced(FORCE FT_WITH_BZIP2)
-        mark_as_advanced(FORCE FT_WITH_HARFBUZZ)
-        mark_as_advanced(FORCE FT_WITH_PNG)
-        mark_as_advanced(FORCE FT_WITH_ZLIB)
+    # Use variables to control freetype CMake options:
+    # Force disable zlib/libpng, to avoid linker errors if theyre pseudo found in system
+    set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB ON CACHE BOOL "" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_LIBPNG ON CACHE BOOL "" FORCE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz ON CACHE BOOL "" FORCE)
+    set(FT_WITH_HARFBUZZ OFF CACHE BOOL "" FORCE)
+    set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
+    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_ZLIB)
+    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_LIBPNG)
+    mark_as_advanced(FORCE CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz)
+    mark_as_advanced(FORCE SKIP_INSTALL_ALL)
+    mark_as_advanced(FORCE FT_WITH_BZIP2)
+    mark_as_advanced(FORCE FT_WITH_HARFBUZZ)
+    mark_as_advanced(FORCE FT_WITH_PNG)
+    mark_as_advanced(FORCE FT_WITH_ZLIB)
 
-        # Freetype includes CMakeLists.txt so we can use MakeAvailable
-        FetchContent_MakeAvailable(freetype)
-        
-        # Freetype with MSVC on windows emits warnings at /W1 (default). Use a cmake function defined elsewhere to suppress all warnings on the freetype target
-        include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
-        if(TARGET freetype)
-            DisableCompilerWarnings(TARGET freetype)
-        endif()
+    # Freetype includes CMakeLists.txt so we can use MakeAvailable
+    FetchContent_MakeAvailable(freetype)
+    
+    # Freetype with MSVC on windows emits warnings at /W1 (default). Use a cmake function defined elsewhere to suppress all warnings on the freetype target
+    include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
+    if(TARGET freetype)
+        DisableCompilerWarnings(TARGET freetype)
     endif()
 endif()

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -9,23 +9,20 @@ if(UNIX)
                             "e.g. sudo apt install libglew-dev")
     endif ()
 elseif(WIN32)
-    # On windows, if GLEW cannot be found, it is downloaded and CMake is told how to find it (via config mode)
-    find_package(GLEW QUIET)
-    if(NOT GLEW_FOUND)
-        # Declare source properties
-        FetchContent_Declare(
-            glew
-            URL "https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0-win32.zip"
-        )
-        FetchContent_GetProperties(glew)
-        if(NOT glew_POPULATED)
-            # Download content
-            FetchContent_Populate(glew)
-            # Create a Cmake configuraiton file for glew (the download is not cmake aware)
-            set(GLEW_DIR ${glew_SOURCE_DIR})
-            configure_file(${CMAKE_CURRENT_LIST_DIR}/glew-config.cmake.in ${glew_SOURCE_DIR}/glew-config.cmake @ONLY)
-            # Find it again. Erroring if it cannot be found.
-            find_package(GLEW REQUIRED)
-        endif()
+    # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
+    # Declare source properties
+    FetchContent_Declare(
+        glew
+        URL "https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0-win32.zip"
+    )
+    FetchContent_GetProperties(glew)
+    if(NOT glew_POPULATED)
+        # Download content
+        FetchContent_Populate(glew)
+        # Create a Cmake configuraiton file for glew (the download is not cmake aware)
+        set(GLEW_DIR ${glew_SOURCE_DIR})
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/glew-config.cmake.in ${glew_SOURCE_DIR}/glew-config.cmake @ONLY)
+        # Find it again. Erroring if it cannot be found.
+        find_package(GLEW REQUIRED)
     endif()
 endif()

--- a/cmake/dependencies/sdl2.cmake
+++ b/cmake/dependencies/sdl2.cmake
@@ -8,23 +8,20 @@ if(UNIX)
                         "e.g. sudo apt install libsdl2-dev")
     endif ()
 elseif(WIN32)
-    # On windows, if SDL2 cannot be found, it is downloaded and CMake is told how to find it (via config mode)
-    find_package(SDL2 QUIET)
-    if(NOT SDL2_FOUND)
-        # Declare source properties
-        FetchContent_Declare(
-            SDL2
-            URL "https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip"
-        )
-        FetchContent_GetProperties(SDL2)
-        if(NOT SDL2_POPULATED)
-            # Download content
-            FetchContent_Populate(SDL2)
-            # Create a Cmake configuraiton file for SDL2 (the download is not cmake aware)
-            set(SDL2_DIR ${sdl2_SOURCE_DIR})
-            configure_file(${CMAKE_CURRENT_LIST_DIR}/sdl2-config.cmake.in ${sdl2_SOURCE_DIR}/sdl2-config.cmake @ONLY)
-            # Find it again. Erroring if it cannot be found.
-            find_package(SDL2 REQUIRED)
-        endif()
+    # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
+    # Declare source properties
+    FetchContent_Declare(
+        SDL2
+        URL "https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip"
+    )
+    FetchContent_GetProperties(SDL2)
+    if(NOT SDL2_POPULATED)
+        # Download content
+        FetchContent_Populate(SDL2)
+        # Create a Cmake configuraiton file for SDL2 (the download is not cmake aware)
+        set(SDL2_DIR ${sdl2_SOURCE_DIR})
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/sdl2-config.cmake.in ${sdl2_SOURCE_DIR}/sdl2-config.cmake @ONLY)
+        # Find it again. Erroring if it cannot be found.
+        find_package(SDL2 REQUIRED)
     endif()
 endif()


### PR DESCRIPTION
There are issues with CMakes find package with multi-config generators / msvc, where a release lib will be found but not debug, which can break the build (apparently).