### PR TITLE
Rename the vis target flamegpu_visualiser

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT GIT_FOUND)
 endif ()
 
 # Set the project name, but do not specify languages immediately so we can have lint only builds.
-project(flamegpu2_visualiser)
+project(flamegpu_visualiser)
 
 # handle cpplint.
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cpplint.cmake)


### PR DESCRIPTION
This is to match the changes to the main flamegpu library.

Must be merged at the same time as the matching PR on the main repo (https://github.com/FLAMEGPU/FLAMEGPU2/pull/614)