### PR TITLE
Manylinux2014 Support

### DIFF
--- a/.github/scripts/install_cuda_ubuntu.sh
+++ b/.github/scripts/install_cuda_ubuntu.sh
@@ -1,0 +1,181 @@
+# @todo - better / more robust parsing of inputs from env vars.
+## -------------------
+## Constants
+## -------------------
+
+# List of sub-packages to install.
+# @todo - pass this in from outside the script? 
+# @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
+
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble pre cuda 10.
+CUDA_PACKAGES_IN=(
+    "cuda-compiler"
+    "cuda-cudart-dev"
+    "cuda-nvtx"
+    "cuda-nvrtc-dev"
+    "libcurand-dev" # 11-0+
+)
+
+## -------------------
+## Bash functions
+## -------------------
+# returns 0 (true) if a >= b
+function version_ge() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+}
+# returns 0 (true) if a > b
+function version_gt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_ge $1 $2
+}
+# returns 0 (true) if a <= b
+function version_le() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+}
+# returns 0 (true) if a < b
+function version_lt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_le $1 $2
+}
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as $cuda.
+CUDA_VERSION_MAJOR_MINOR=${cuda}
+
+# Split the version.
+# We (might/probably) don't know PATCH at this point - it depends which version gets installed.
+CUDA_MAJOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f1)
+CUDA_MINOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f2)
+CUDA_PATCH=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f3)
+# use lsb_release to find the OS.
+UBUNTU_VERSION=$(lsb_release -sr)
+UBUNTU_VERSION="${UBUNTU_VERSION//.}"
+
+echo "CUDA_MAJOR: ${CUDA_MAJOR}"
+echo "CUDA_MINOR: ${CUDA_MINOR}"
+echo "CUDA_PATCH: ${CUDA_PATCH}"
+# echo "UBUNTU_NAME: ${UBUNTU_NAME}"
+echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
+
+# If we don't know the CUDA_MAJOR or MINOR, error.
+if [ -z "${CUDA_MAJOR}" ] ; then
+    echo "Error: Unknown CUDA Major version. Aborting."
+    exit 1
+fi
+if [ -z "${CUDA_MINOR}" ] ; then
+    echo "Error: Unknown CUDA Minor version. Aborting."
+    exit 1
+fi
+# If we don't know the Ubuntu version, error.
+if [ -z ${UBUNTU_VERSION} ]; then
+    echo "Error: Unknown Ubuntu version. Aborting."
+    exit 1
+fi
+
+
+## -------------------------------
+## Select CUDA packages to install
+## -------------------------------
+CUDA_PACKAGES=""
+for package in "${CUDA_PACKAGES_IN[@]}"
+do : 
+    # @todo This is not perfect. Should probably provide a separate list for diff versions
+    # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
+    if [[ "${package}" == "cuda-nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="cuda-compiler"
+    elif [[ "${package}" == "cuda-compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="cuda-nvcc"
+    fi
+    # CUDA 11+ includes lib* / lib*-dev packages, which if they existed previously where cuda-cu*- / cuda-cu*-dev-
+    if [[ ${package} == libcu* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
+        package="${package/libcu/cuda-cu}"
+    fi
+
+    # Build the full package name and append to the string.
+    CUDA_PACKAGES+=" ${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+done
+echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
+
+## -----------------
+## Prepare to install
+## -----------------
+
+PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
+PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
+APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+
+echo "PIN_FILENAME ${PIN_FILENAME}"
+echo "PIN_URL ${PIN_URL}"
+echo "APT_KEY_URL ${APT_KEY_URL}"
+
+## -----------------
+## Check for root/sudo
+## -----------------
+
+# Detect if the script is being run as root, storing true/false in is_root.
+is_root=false
+if (( $EUID == 0)); then
+   is_root=true
+fi
+# Find if sudo is available
+has_sudo=false
+if command -v sudo &> /dev/null ; then
+    has_sudo=true
+fi
+# Decide if we can proceed or not (root or sudo is required) and if so store whether sudo should be used or not. 
+if [ "$is_root" = false ] && [ "$has_sudo" = false ]; then 
+    echo "Root or sudo is required. Aborting."
+    exit 1
+elif [ "$is_root" = false ] ; then
+    USE_SUDO=sudo
+else
+    USE_SUDO=
+fi
+
+## -----------------
+## Install
+## -----------------
+echo "Adding CUDA Repository"
+wget ${PIN_URL}
+$USE_SUDO mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
+$USE_SUDO apt-key adv --fetch-keys ${APT_KEY_URL}
+$USE_SUDO add-apt-repository "deb ${REPO_URL} /"
+$USE_SUDO apt-get update
+
+echo "Installing CUDA packages ${CUDA_PACKAGES}"
+$USE_SUDO apt-get -y install ${CUDA_PACKAGES}
+
+if [[ $? -ne 0 ]]; then
+    echo "CUDA Installation Error."
+    exit 1
+fi
+
+## -----------------
+## Set environment vars / vars to be propagated
+## -----------------
+
+CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
+echo "CUDA_PATH=${CUDA_PATH}"
+export CUDA_PATH=${CUDA_PATH}
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$LD_LIBRARY_PATH"
+# Check nvcc is now available.
+nvcc -V
+
+
+# If executed on github actions, make the appropriate echo statements to update the environment
+if [[ $GITHUB_ACTIONS ]]; then
+    # Set paths for subsequent steps, using ${CUDA_PATH}
+    echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+    echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+    echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+fi

--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -22,6 +22,12 @@ $CUDA_KNOWN_URLS = @{
     "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
     "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
+    "11.2.1" = "https://developer.download.nvidia.com/compute/cuda/11.2.1/network_installers/cuda_11.2.1_win10_network.exe";
+    "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
+    "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe"
+    "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe"
+    "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe"
+    "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
@@ -165,3 +171,12 @@ Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
 # PATH needs updating elsewhere, anything in here won't persist.
 # Append $CUDA_PATH/bin to path.
 # Set CUDA_PATH as an environmental variable
+
+# If executing on github actions, emit the appropriate echo statements to update environment variables
+if (Test-Path "env:GITHUB_ACTIONS") { 
+    # Set paths for subsequent steps, using $env:CUDA_PATH
+    echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+    echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -3,32 +3,52 @@ name: Lint
 
 on:
   push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/Lint.yml"
   pull_request:
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   cpplint:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.cudacxx.os }}
+    name: "cpplint (${{ matrix.cudacxx.cuda }}, ${{ matrix.cudacxx.os }})"
     strategy:
       fail-fast: false
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
       matrix:
-        include:
-          - os: ubuntu-18.04
-            cuda: "11.2"
+        cudacxx:
+          - cuda: "11.0"
+            os: ubuntu-20.04
     env:
-      build_dir: "build"
+      # Define constants
+      BUILD_DIR: "build"
+      BUILD_TESTS: "ON"
+      # Port matrix options to environment, for more portability.
+      CUDA: ${{ matrix.cudacxx.cuda }}
+      OS: ${{ matrix.cudacxx.os }}
 
     steps:
     - uses: actions/checkout@v2
 
-    # Also install the linter.
     - name: Install cpplint
-      run: pip3 install cpplint && echo "$HOME/.local/bin" >> $GITHUB_PATH
+      run: |
+        python3 -m pip install cpplint
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    # Configure cmake, including tests to make sure they are linted.
     - name: Configure cmake
-      run: cmake . -B ${{ env.build_dir }} -DALLOW_LINT_ONLY=ON
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}"
+        -DALLOW_LINT_ONLY=ON
 
-    # Run the linter.
     - name: Lint
+      working-directory: ${{ env.BUILD_DIR }}
       run: cmake --build . --target all_lint --verbose -j `nproc` 
-      working-directory: ${{ env.build_dir }}
+

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -1,0 +1,111 @@
+# Build within the manylinux 2014 container, to check ensure compatability for python wheels.
+name: Manylinux2014
+
+# Run on branch push events (i.e. not tag pushes) and on pull requests
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/Manylinux2014.yml"
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+# A single job, which builds manylinux2014 wheels, which ships with GCC 10.2.1 at the time of writing. If this bumps to unpatched 10.3 we might have issues w/ cuda. 
+jobs:
+  build:
+    runs-on: ${{ matrix.cudacxx.os }}
+    # Run steps inside a manylinux container.
+    container: quay.io/pypa/manylinux2014_x86_64
+    strategy:
+      fail-fast: false
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
+      matrix:
+        cudacxx:
+          - cuda: "11.0"
+            cuda_arch: "35"
+            hostcxx: devtoolset-9
+            os: ubuntu-20.04
+          # - cuda: "10.0"
+          #   cuda_arch: "35"
+          #   hostcxx: devtoolset-7
+          #   os: ubuntu-18.04
+        config:
+          - name: "Release"
+            config: "Release"
+
+    # Name the job based on matrix/env options
+    name: "build (${{ matrix.cudacxx.cuda }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
+
+    env:
+      # Define constants
+      BUILD_DIR: "build"
+      # Port matrix options to environment, for more portability.
+      CUDA: ${{ matrix.cudacxx.cuda }}
+      CUDA_ARCH: ${{ matrix.cudacxx.cuda_arch }}
+      HOSTCXX: ${{ matrix.cudacxx.hostcxx }}
+      OS: ${{ matrix.cudacxx.os }}
+      CONFIG: ${{ matrix.config.config }}
+      # Kept for portable steps between this and the main repository.
+      VISUALISATION: "ON"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Downgrade the devtoolset in the image based on the build matrix, using:
+    # gcc-10 for CUDA >= 11.2. Unclear if devtoolset-10 will upgrade to unpatched 11.3 which breaks CUDA builds that use <chrono>. 
+    # gcc-9 for CUDA >= 11.0
+    # gcc-8 for CUDA >= 10.1
+    # gcc-7 for CUDA >= 10.0 (and probably 9.x).
+    # these are not the officially supported toolset on centos by cuda, but it's what works.
+    - name: Install RHEL devtoolset (CentOS)
+      if: ${{ startsWith(env.HOSTCXX, 'devtoolset-') }}
+      run: |
+        # Install devtoolset-X
+        yum install -y ${{ env.HOSTCXX }}
+        # Enable the toolset via source not scl enable which doesn't get on with multi-step GHA 
+        source /opt/rh/${{ env.HOSTCXX }}/enable
+        # Export the new environment / compilers for subsequent steps.
+        echo "PATH=${PATH}" >> $GITHUB_ENV
+        echo "CC=$(which gcc)" >> $GITHUB_ENV
+        echo "CXX=$(which g++)" >> $GITHUB_ENV
+        echo "CUDAHOSTCXX=$(which g++)" >> $GITHUB_ENV
+
+    - name: Install CUDA (CentOS)
+      if: ${{ env.CUDA != '' }}
+      env:
+        cuda: ${{ env.CUDA }}
+      run: .github/scripts/install_cuda_centos.sh
+
+    - name: Install Visualisation Dependencies (CentOS)
+      if: ${{ env.VISUALISATION == 'ON' }}
+      run: |
+        yum install -y mesa-libGLU-devel glew-devel fontconfig-devel SDL2-devel freetype-devel 
+        # Build/Install DevIL from source.
+        yum install -y freeglut-devel
+        git clone --depth 1 https://github.com/DentonW/DevIL.git
+        cd DevIL/DevIL
+        mkdir -p build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=${{ env.CONFIG }} -Wno-error=dev
+        make -j `nproc`
+        make install
+
+    - name: Configure cmake
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}"
+        -DCMAKE_BUILD_TYPE="${{ env.CONFIG }}"
+        -Werror=dev
+        -DCMAKE_WARN_DEPRECATED="OFF" 
+        -DWARNINGS_AS_ERRORS="OFF"
+        -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
+
+    - name: Build
+      working-directory: ${{ env.BUILD_DIR }}
+      run: cmake --build . --target all --verbose -j `nproc`

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -3,57 +3,94 @@ name: Ubuntu
 
 on:
   push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/Ubuntu.yml"
   pull_request:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  build-visualiser:
-    runs-on: ${{ matrix.os }}
+  build:
+    runs-on: ${{ matrix.cudacxx.os }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
       matrix:
-        include:
-          # 20.04 supports CUDA 11.0+ (gcc >= 5 && gcc <= 10). SM < 52 deprecated since 11.0
-          - os: ubuntu-20.04
-            cuda: "11.4"
-            cuda_arch: "52"
-            gcc: 9
+        cudacxx:
+          - cuda: "11.0"
+            cuda_arch: "35"
+            hostcxx: gcc-9
+            os: ubuntu-20.04
+          # - cuda: "10.0"
+          #   cuda_arch: "35"
+          #   hostcxx: gcc-7
+          #   os: ubuntu-18.04
+        config:
+          - name: "Release"
+            config: "Release"
+
+    # Name the job based on matrix/env options
+    name: "build (${{ matrix.cudacxx.cuda }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
+
+    # Define job-wide env constants, and promote matrix elements to env constants for portable steps.
     env:
-      build_dir: "build"
-      config: "Release"
-      Werror: "ON"
+      # Define constants
+      BUILD_DIR: "build"
+      # Port matrix options to environment, for more portability.
+      CUDA: ${{ matrix.cudacxx.cuda }}
+      CUDA_ARCH: ${{ matrix.cudacxx.cuda_arch }}
+      HOSTCXX: ${{ matrix.cudacxx.hostcxx }}
+      OS: ${{ matrix.cudacxx.os }}
+      CONFIG: ${{ matrix.config.config }}
+      # Kept for portable steps between this and the main repository.
+      VISUALISATION: "ON"
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install CUDA
+      if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:
-        cuda: ${{ matrix.cuda }}
+        cuda: ${{ env.CUDA }}
+      run: .github/scripts/install_cuda_ubuntu.sh
+
+    - name: Install/Select gcc and g++
+      if: ${{ startsWith(env.HOSTCXX, 'gcc-') }}
       run: |
-        source ./scripts/actions/install_cuda_ubuntu.sh
-        if [[ $? -eq 0 ]]; then
-          # Set paths for subsequent steps, using ${CUDA_PATH}
-          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
-          echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
-          echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
-          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        gcc_version=${HOSTCXX//gcc-/}
+        sudo apt-get install -y gcc-${gcc_version} g++-${gcc_version}
+        echo "CC=/usr/bin/gcc-${gcc_version}" >> $GITHUB_ENV
+        echo "CXX=/usr/bin/g++-${gcc_version}" >> $GITHUB_ENV
+        echo "CUDAHOSTCXX=/usr/bin/g++-${gcc_version}" >> $GITHUB_ENV
+
+    - name: Install Visualisation Dependencies
+      if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}
+      run: |
+        # Install ubuntu-20.04 packages
+        if [ "$OS" == 'ubuntu-20.04' ]; then 
+          sudo apt-get install -y libglew-dev libglu1-mesa-dev libfontconfig1-dev libsdl2-dev libdevil-dev libfreetype-dev
         fi
-      shell: bash
-
-    # Specify the correct host compilers
-    - name: Install/Select gcc and g++ 
-      run: |
-        sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
-        echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
-        echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
-
-    - name: Install visualisation dev dependencies
-      run: sudo apt-get install libsdl2-dev libglew-dev libfreetype-dev libdevil-dev libglu1-mesa-dev libfontconfig1-dev
+        # Install Ubuntu 18.04 packages
+        if [ "$OS" == 'ubuntu-18.04' ]; then 
+          sudo apt-get install -y libglew-dev libglu1-mesa-dev libfontconfig1-dev libsdl2-dev libdevil-dev libfreetype6-dev libgl1-mesa-dev
+        fi
 
     - name: Configure cmake
-      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -DWARNINGS_AS_ERRORS=${{ env.Werror }} -Werror=dev
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}"
+        -DCMAKE_BUILD_TYPE="${{ env.CONFIG }}"
+        -Werror=dev
+        -DCMAKE_WARN_DEPRECATED="OFF" 
+        -DWARNINGS_AS_ERRORS="ON"
+        -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
 
-    - name: Build Visualiser
+    - name: Build
+      working-directory: ${{ env.BUILD_DIR }}
       run: cmake --build . --target all --verbose -j `nproc`
-      working-directory: ${{ env.build_dir }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,52 +1,74 @@
-# Windows builds.
+# Compile project on Windows
 name: Windows
 
 on:
   push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/Windows.yml"
   pull_request:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  build-visualiser:
-    runs-on: ${{ matrix.os }}
+  build:
+    runs-on: ${{ matrix.cudacxx.os }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
       matrix:
-        include:
-          # Windows2019 & VS 2019 supports 10.1+
-          - os: windows-2019
-            cuda: "11.2.0"
-            cuda_arch: "52"
-            visual_studio: "Visual Studio 16 2019"
+        cudacxx:
+          - cuda: "11.0.3"
+            cuda_arch: "35"
+            hostcxx: "Visual Studio 16 2019"
+            os: windows-2019
+        config:
+          - name: "Release"
+            config: "Release"
+
+    # Name the job based on matrix/env options
+    name: "build (${{ matrix.cudacxx.cuda }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
+
+    # Define job-wide env constants, and promote matrix elements to env constants for portable steps.
     env:
-      build_dir: "build"
-      config: "Release"
-      Werror: "ON"
+      # Define constants
+      BUILD_DIR: "build"
+      BUILD_TESTS: "OFF"
+      # Port matrix options to environment, for more portability.
+      CUDA: ${{ matrix.cudacxx.cuda }}
+      CUDA_ARCH: ${{ matrix.cudacxx.cuda_arch }}
+      HOSTCXX: ${{ matrix.cudacxx.hostcxx }}
+      OS: ${{ matrix.cudacxx.os }}
+      CONFIG: ${{ matrix.config.config }}
+      # Kept for portable steps between this and the main repository.
+      VISUALISATION: "ON"
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install CUDA
-      env: 
-        cuda: ${{ matrix.cuda }}
-        visual_studio: ${{ matrix.visual_studio }}
-      run: |
-        # Install CUDA via a powershell script
-        .\scripts\actions\install_cuda_windows.ps1
-        if ($?) {
-          # Set paths for subsequent steps, using $env:CUDA_PATH
-          echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
-          echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        }
+    - name: Install CUDA (Windows)
+      if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
       shell: powershell
+      env:
+        cuda: ${{ env.CUDA }}
+        visual_studio: ${{ env.HOSTCXX }}
+      run: .github\scripts\install_cuda_windows.ps1
 
-    - name: Configure CMake
-      id: configure
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DCUDA_ARCH="${{ matrix.cuda_arch }}" -DWARNINGS_AS_ERRORS=${{ env.Werror }} -Werror=dev
-      shell: bash
+    - name: Configure cmake
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}" 
+        -G "${{ env.HOSTCXX }}" -A x64
+        -Werror=dev
+        -DCMAKE_WARN_DEPRECATED="OFF"
+        -DWARNINGS_AS_ERRORS="ON"
+        -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
 
-    - name: Build Visualiser
-      run: cmake --build . --config ${{ env.config }} --target ALL_BUILD --verbose
-      working-directory: ${{ env.build_dir }}
+    - name: Build
+      working-directory: ${{ env.BUILD_DIR }}
+      run: cmake --build . --config ${{ env.CONFIG }} --target ALL_BUILD --verbose -j `nproc`

--- a/src/flamegpu/visualiser/ui/Text.cpp
+++ b/src/flamegpu/visualiser/ui/Text.cpp
@@ -393,7 +393,8 @@ Text::TextureString::~TextureString() {
     }
 }
 void Text::TextureString::paintGlyph(FT_Bitmap glyph, unsigned int penX, unsigned int penY) {
-    for (unsigned int y = 0; y < glyph.rows; y++) {
+    // The static_cast on glyph.rows is required for warning supperssion with older versions of freetype such as in CenotOs 7
+    for (unsigned int y = 0; y < static_cast<unsigned int>(glyph.rows); y++) {
         // src ptr maps to the start of the current row in the glyph
         unsigned char *src_ptr = glyph.buffer + y*glyph.pitch;
         // dst ptr maps to the pens current Y pos, adjusted for the current glyph row
@@ -407,7 +408,8 @@ void Text::TextureString::paintGlyph(FT_Bitmap glyph, unsigned int penX, unsigne
     }
 }
 void Text::TextureString::paintGlyphMono(FT_Bitmap glyph, unsigned int penX, unsigned int penY) {
-    for (unsigned int y = 0; y < glyph.rows; y++) {
+    // The static_cast on glyph.rows is required for warning supperssion with older versions of freetype such as in CenotOs 7
+    for (unsigned int y = 0; y < static_cast<unsigned int>(glyph.rows); y++) {
         // src ptr maps to the start of the current row in the glyph
         unsigned char *src_ptr = glyph.buffer + y*glyph.pitch;
         // dst ptr maps to the pens current Y pos, adjusted for the current glyph row


### PR DESCRIPTION
+ Fixes warnings when building on CentOS 7 / in manylinux 2014 images due different types used in older versions of freetype
+ Adds a manylinux CI and centos CUDA install script to ensure compatability with python wheel building of the main repo
+ Updates other install scripts / CI to match the new style of the main repository