### PR TITLE
Adjust CMake Logic for GLEW and OpenGL to improve manylinux viability

### DIFF
--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -44,6 +44,8 @@ jobs:
     name: "build (${{ matrix.cudacxx.cuda }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
 
     env:
+      # Control if static GLEW should be built and used or not.
+      USE_STATIC_GLEW: "ON"
       # Define constants
       BUILD_DIR: "build"
       # Port matrix options to environment, for more portability.
@@ -97,6 +99,19 @@ jobs:
         make -j `nproc`
         make install
 
+    - name: Build and install GLEW including static GLEW
+      if: ${{ env.VISUALISATION == 'ON' && env.USE_STATIC_GLEW == 'ON' }}
+      env:
+        GLEW_VERSION: "2.2.0"
+      run: |
+        yum install -y wget
+        wget https://github.com/nigels-com/glew/releases/download/glew-${{ env.GLEW_VERSION }}/glew-${{ env.GLEW_VERSION }}.tgz
+        tar -zxf glew-${{ env.GLEW_VERSION }}.tgz
+        cd glew-${{ env.GLEW_VERSION }}
+        make
+        make install
+
+    # For manylinux, also set if Using static glew, and to use legacy opengl bindings.
     - name: Configure cmake
       run: >
         cmake . -B "${{ env.BUILD_DIR }}"
@@ -105,6 +120,8 @@ jobs:
         -DCMAKE_WARN_DEPRECATED="OFF" 
         -DWARNINGS_AS_ERRORS="OFF"
         -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
+        -DGLEW_USE_STATIC_LIBS="${{ env.USE_STATIC_GLEW }}"
+        -DOpenGL_GL_PREFERENCE:STRING=LEGACY
 
     - name: Build
       working-directory: ${{ env.BUILD_DIR }}

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -3,6 +3,7 @@
 
 if(UNIX)
     # On Linux, if glew is not available the user is instructed to install it themselves.
+    # Users can opt-into static glew, by setting -DGLEW_USE_STATIC_LIBS=ON
     find_package(GLEW)
     if (NOT GLEW_FOUND)
         message(FATAL_ERROR "glew is required for building, install it via your package manager.\n"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,20 @@ if(CMAKE_CUDA_COMPILER)
     include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cuda_arch.cmake)
 endif()
 
-# Check to see if OpenGL is available.
-include(FindOpenGL)
+# Openg GL is required, unless doing a lint only build.
+
+# Under linux, glnvd is prefferred, unless building portable binaries (i.e. manylinux) in which case the legacy must be used. Control via -DOpenGL_GL_PREFERENCE:STRING=LEGACY 
+# This might not be compatble with EGL, if required in the future (remove vis, docker vis). Therefore conda might be preffered.
+# Use the OpenGL::GL target, and check OPENGL_gl_LIBRARY to determine if using legacy or not.
+find_package(OpenGL)
+# Output status message confirming which opengl is being used. 
+if (UNIX AND OPENGL_FOUND)
+    if(OPENGL_gl_LIBRARY STREQUAL "")
+        message(STATUS "Using GLVND OpenGL (libOpenGL.so)")
+    else()
+        message(STATUS "Using Legacy OpenGL (libGL.so)")
+    endif()
+endif()
 
 # If CUDA was not found, or opengl was not found we cannot build, but can lint, otherwise tehre should be a fatal error
 set(LINT_ONLY_BUILD "OFF")
@@ -257,7 +269,13 @@ endif()
 # Strip trailiing whitespace from SDL2_Libraries for Ubuntu1604 / libsdl2-dev 2.0.4
 string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
 target_link_libraries("${PROJECT_NAME}" "${SDL2_LIBRARIES}")
-target_link_libraries("${PROJECT_NAME}" "${GLEW_LIBRARIES}")
+# Link against GLEW, via GLEW::GLEW which is an alias for GLEW::glew or GLEW::glew_s based on availability. 
+if(TARGET GLEW::GLEW)
+    target_link_libraries("${PROJECT_NAME}" GLEW::GLEW)
+else()
+    # Fallback to the variable for our partial windows CMake config file. We should add an imported target alias to this.
+    target_link_libraries("${PROJECT_NAME}" "${GLEW_LIBRARIES}")
+endif()
 target_link_libraries("${PROJECT_NAME}" freetype)
 target_link_libraries("${PROJECT_NAME}" "${IL_LIBRARIES}")
 target_link_libraries("${PROJECT_NAME}" OpenGL::GL)


### PR DESCRIPTION
+ Use Static GLEW if available and requested via cmake flag
+ Use Legacy OpenGL if requested, rather than GLVND on linux
    + Might make manylinux compatibility viable
    + Might prevent EGL use in the future (when building for manylinux)
+ Updates Manylinux CI to make use of these features