### PR TITLE
Make the visualiser library include directory PUBLIC 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,7 +249,9 @@ if(Fontconfig_FOUND)
     target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${Fontconfig_INCLUDE_DIRS})
 endif()
 target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../external")
-target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+# The main include directory should be public.
+target_include_directories("${PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+# The source directory should be private
 target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/")
 
 # Enable fPIC for linux shared library linking


### PR DESCRIPTION
This will remove the need to explicitly add the include directory in the main flamegpu CMakeLists