### PR TITLE
Update CMake minimum version to 3.18

### DIFF
--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -30,7 +30,7 @@ jobs:
         cudacxx:
           - cuda: "11.0"
             cuda_arch: "35"
-            hostcxx: devtoolset-9
+            hostcxx: devtoolset-8
             os: ubuntu-20.04
           # - cuda: "10.0"
           #   cuda_arch: "35"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         cudacxx:
           - cuda: "11.0"
             cuda_arch: "35"
-            hostcxx: gcc-9
+            hostcxx: gcc-8
             os: ubuntu-20.04
           # - cuda: "10.0"
           #   cuda_arch: "35"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 # Parity with main FGPU2 CMake
-cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION VERSION 3.18 FATAL_ERROR)
 
 project(FLAMEGPU2_VISUALISER LANGUAGES NONE)
 
 # Don't create installation scripts (and hide CMAKE_INSTALL_PREFIX from cmake-gui)
 set(CMAKE_SKIP_INSTALL_RULES TRUE)
 set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE INTERNAL ""  FORCE)
+
+# Ensure this is not an in-source build
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/OutOfSourceOnly.cmake)
 
 # Define some CMake Options which apply to all (sub) projects
 

--- a/cmake/CommonCompilerSettings.cmake
+++ b/cmake/CommonCompilerSettings.cmake
@@ -1,0 +1,67 @@
+# Define a function which can be used to set common compiler options for a target
+# We do not want to force these options on end users (although they should be used ideally), hence not just public properties on the library target
+# Function to suppress compiler warnings for a given target
+function(CommonCompilerSettings)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        CCS
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT CCS_TARGET)
+        message( FATAL_ERROR "function(CommonCompilerSettings): 'TARGET' argument required")
+    elseif(NOT TARGET ${CCS_TARGET} )
+        message( FATAL_ERROR "function(CommonCompilerSettings): TARGET '${CCS_TARGET}' is not a valid target")
+    endif()
+
+    # Add device debugging symbols to device builds of CUDA objects
+    target_compile_options(${CCS_TARGET} PRIVATE "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G>")
+    # Ensure DEBUG and _DEBUG are defined for Debug builds
+    target_compile_definitions(${CCS_TARGET} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:DEBUG>)
+    target_compile_definitions(${CCS_TARGET} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:_DEBUG>)
+    # Enable -lineinfo for Release builds, for improved profiling output.
+    target_compile_options(${CCS_TARGET} PRIVATE "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-lineinfo>")
+
+    # Set an NVCC flag which allows host constexpr to be used on the device.
+    target_compile_options(${CCS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>")
+
+    # Prevent windows.h from defining max and min.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_definitions(${CCS_TARGET} PRIVATE NOMINMAX)
+    endif()
+
+    # Pass the SEATBELTS macro, which when set to off/0 (for non debug builds) removes expensive operations.
+    if (SEATBELTS)
+        # If on, all build configs have  seatbelts
+        target_compile_definitions(${CCS_TARGET} PRIVATE SEATBELTS=1)
+    else()
+        # Id off, debug builds have seatbelts, non debug builds do not.
+        target_compile_definitions(${CCS_TARGET} PRIVATE $<IF:$<CONFIG:Debug>,SEATBELTS=1,SEATBELTS=0>)
+    endif()
+
+    # MSVC handling of SYSTEM for external includes.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
+        # These flags don't currently have any effect on how CMake passes system-private includes to msvc (VS 2017+)
+        set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I")
+        set(CMAKE_INCLUDE_SYSTEM_FLAG_CUDA "/external:I")
+        # VS 2017+
+        target_compile_options(${CCS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/experimental:external>")
+    endif()
+
+    # Enable parallel compilation
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(${CCS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /MP>")
+        target_compile_options(${CCS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/MP>")
+    endif()
+
+    # If CUDA 11.2+, can build multiple architectures in parallel. 
+    # Note this will be multiplicative against the number of threads launched for parallel cmake build, which may lead to processes being killed, or excessive memory being consumed.
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND USE_NVCC_THREADS AND DEFINED NVCC_THREADS AND NVCC_THREADS GREATER_EQUAL 0)
+        target_compile_options(${CCS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--threads ${NVCC_THREADS}>")
+    endif()
+
+endfunction()

--- a/cmake/OutOfSourceOnly.cmake
+++ b/cmake/OutOfSourceOnly.cmake
@@ -1,0 +1,19 @@
+# Define a cmake function which emits a fatal error if the source directory and binary directory are the same.
+function(EnforceOutOfSourceBuilds)
+    # Resolve paths before comparioson to ensure comparions are accurate
+    get_filename_component(source_dir "${CMAKE_SOURCE_DIR}" REALPATH)
+    get_filename_component(binary_dir "${CMAKE_BINARY_DIR}" REALPATH)
+
+    if("${source_dir}" STREQUAL "${binary_dir}")
+        message(FATAL_ERROR 
+            " In-source CMake builds are not allowed.\n"
+            " Use a build directory i.e. cmake -B build.\n"
+            " You may have to clear/delete the generated CMakeCache.txt and CMakeFiles/:\n"
+            "   ${binary_dir}/CMakeCache.txt\n"
+            "   ${binary_dir}/CMakeFiles/\n")
+    endif()
+endfunction()
+
+# Call the function imediately, so the file only needs to be included. 
+EnforceOutOfSourceBuilds()
+

--- a/cmake/cuda_arch.cmake
+++ b/cmake/cuda_arch.cmake
@@ -1,121 +1,134 @@
-# From the main project. @todo - find a way to make this common between them / reduce duplicate effort?
-# Build a list of gencode arguments, based on CUDA verison.
-# Accepts user override via CUDA_ARCH
+# Provides a per target function to set gencode compiler options.
+# Function to suppress compiler warnings for a given target
+# If the cmake variable CUDA_ARCH is set, to a non emtpy list or space separated string this will be used instead.
+# @todo - find a way to warn about  deprecated architectures once and only once (at cmake time?) Might need to just try compiling with old warnings and capture / post process the output. 
+# @todo - figure out how to do this once and only once as a function rather than a macro.
+macro(SetCUDAGencodes)
+    # @todo - only get the available gencodes from nvcc once, rather than per target.
 
-# CMAKE > 3.18 introduces CUDA_ARCHITECTURES as a cmake-native way of generating gencodes (Policy CMP0104). Set the value to OFF to prevent errors for it being not provided.
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18")
-    set(CMAKE_CUDA_ARCHITECTURES "OFF")
-endif()
-
-
-# Check if any have been provided by the users
-string(LENGTH "${CUDA_ARCH}" CUDA_ARCH_LENGTH)
-
-# Define the default compute capabilites incase not provided by the user
-set(DEFAULT_CUDA_ARCH "20;35;50;60;70;80;")
-
-# Get the valid options for the current compiler.
-# Run nvcc --help to get the help string which contains all valid compute_ sm_ for that version.
-execute_process(COMMAND ${CMAKE_CUDA_COMPILER} "--help" OUTPUT_VARIABLE NVCC_HELP_STR ERROR_VARIABLE NVCC_HELP_STR)
-# Match all comptue_XX or sm_XXs
-string(REGEX MATCHALL "'(sm|compute)_[0-9]+'" SUPPORTED_CUDA_ARCH "${NVCC_HELP_STR}" )
-# Strip just the numeric component
-string(REGEX REPLACE "'(sm|compute)_([0-9]+)'" "\\2" SUPPORTED_CUDA_ARCH "${SUPPORTED_CUDA_ARCH}" )
-# Remove dupes and sort to build the correct list of supported CUDA_ARCH.
-list(REMOVE_DUPLICATES SUPPORTED_CUDA_ARCH)
-list(REMOVE_ITEM SUPPORTED_CUDA_ARCH "")
-list(SORT SUPPORTED_CUDA_ARCH)
-
-# Update defaults to only be those supported
-# @todo might be better to instead do a dry run compilation with each gencode to validate?
-foreach(ARCH IN LISTS DEFAULT_CUDA_ARCH)
-    if (NOT ARCH IN_LIST SUPPORTED_CUDA_ARCH)
-        list(REMOVE_ITEM DEFAULT_CUDA_ARCH "${ARCH}")
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        SCG
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT SCG_TARGET)
+        message( FATAL_ERROR "SetCUDAGencodes: 'TARGET' argument required." )
+    elseif(NOT TARGET ${SCG_TARGET} )
+        message( FATAL_ERROR "SetCUDAGencodes: TARGET '${SCG_TARGET}' is not a valid target" )
     endif()
-    list(REMOVE_DUPLICATES CUDA_ARCH)
-    list(REMOVE_ITEM CUDA_ARCH "")
-    list(SORT CUDA_ARCH)
-endforeach()
 
+    # CMAKE > 3.18 introduces CUDA_ARCHITECTURES as a cmake-native way of generating gencodes (Policy CMP0104). Set the value to OFF to prevent errors for it being not provided.
+    # We manually set gencode arguments, so we can (potentially) use LTO and are not restricted to CMake's availble options.
+    set_property(TARGET ${SCG_TARGET} PROPERTY CUDA_ARCHITECTURES OFF)
 
-if(NOT CUDA_ARCH_LENGTH EQUAL 0)
-    # Convert user provided string argument to a list.
-    string (REPLACE " " ";" CUDA_ARCH "${CUDA_ARCH}")
-    string (REPLACE "," ";" CUDA_ARCH "${CUDA_ARCH}")
+    # Define the default compute capabilites incase not provided by the user
+    set(DEFAULT_CUDA_ARCH "35;50;60;70;80;")
 
-    # Remove duplicates, empty items and sort.
-    list(REMOVE_DUPLICATES CUDA_ARCH)
-    list(REMOVE_ITEM CUDA_ARCH "")
-    list(SORT CUDA_ARCH)
+    # Determine if the user has provided a non default CUDA_ARCH value 
+    string(LENGTH "${CUDA_ARCH}" CUDA_ARCH_LENGTH)
 
-    # Validate the list.
-    foreach(ARCH IN LISTS CUDA_ARCH)
-        if (NOT ARCH IN_LIST SUPPORTED_CUDA_ARCH)
-            message(WARNING
-            "  CUDA_ARCH '${ARCH}' not supported by CUDA ${CMAKE_CUDA_COMPILER_VERSION} and is being ignored.\n"
-            "  Choose from: ${SUPPORTED_CUDA_ARCH}")
-            list(REMOVE_ITEM CUDA_ARCH "${ARCH}")
-        endif()
-    endforeach()
+    # Query NVCC in order to filter the provided list. 
+    # @todo only do this once, and re-use the output for a given cmake configure?
 
-    # @todo - validate that the CUDA_ARCH provided are supported by the compiler
-endif()
+    # Get the valid options for the current compiler.
+    # Run nvcc --help to get the help string which contains all valid compute_ sm_ for that version.
+    if(NOT DEFINED SUPPORTED_CUDA_ARCH)
+        execute_process(COMMAND ${CMAKE_CUDA_COMPILER} "--help" OUTPUT_VARIABLE NVCC_HELP_STR ERROR_VARIABLE NVCC_HELP_STR)
+        # Match all comptue_XX or sm_XXs
+        string(REGEX MATCHALL "'(sm|compute)_[0-9]+'" SUPPORTED_CUDA_ARCH "${NVCC_HELP_STR}" )
+        # Strip just the numeric component
+        string(REGEX REPLACE "'(sm|compute)_([0-9]+)'" "\\2" SUPPORTED_CUDA_ARCH "${SUPPORTED_CUDA_ARCH}" )
+        # Remove dupes and sort to build the correct list of supported CUDA_ARCH.
+        list(REMOVE_DUPLICATES SUPPORTED_CUDA_ARCH)
+        list(REMOVE_ITEM SUPPORTED_CUDA_ARCH "")
+        list(SORT SUPPORTED_CUDA_ARCH)
 
-# If the list is empty post validation, set it to the (validated) defaults
-list(LENGTH CUDA_ARCH CUDA_ARCH_LENGTH)
-if(CUDA_ARCH_LENGTH EQUAL 0)
-    set(CUDA_ARCH ${DEFAULT_CUDA_ARCH})
-endif()
-
-# Propagate the validated values to the parent scope, to reduce warning duplication.
-get_directory_property(hasParent PARENT_DIRECTORY)
-if(hasParent)
-    set(CUDA_ARCH ${CUDA_ARCH} PARENT_SCOPE)
-endif()
-# If the list is somehow empty now, do not set any gencodes arguments, instead using the compiler defaults.
-list(LENGTH CUDA_ARCH CUDA_ARCH_LENGTH)
-if(NOT CUDA_ARCH_LENGTH EQUAL 0)
-    # Only do this if required.I.e. CUDA_ARCH is the same as the last time this file was included
-    if(NOT CUDA_ARCH_APPLIED EQUAL CUDA_ARCH)
-        message(STATUS "Generating Compute Capabilities: ${CUDA_ARCH}")
+        # Store the supported arch's once and only once. This could be a cache  var given the cuda compiler should not be able to change without clearing th cache?
+        get_directory_property(hasParent PARENT_DIRECTORY)
         if(hasParent)
-            set(CUDA_ARCH_APPLIED "${CUDA_ARCH}" PARENT_SCOPE )
+            set(SUPPORTED_CUDA_ARCH ${SUPPORTED_CUDA_ARCH} PARENT_SCOPE)
         endif()
     endif()
-    set(GENCODES_FLAGS)
-    set(MIN_CUDA_ARCH)
-    # Convert to gencode arguments
-
-    foreach(ARCH IN LISTS CUDA_ARCH)
-        set(GENCODES_FLAGS "${GENCODES_FLAGS} -gencode arch=compute_${ARCH},code=sm_${ARCH}")
+    
+    
+    # Update defaults to only be those supported
+    # @todo might be better to instead do a dry run compilation with each gencode to validate?
+    foreach(ARCH IN LISTS DEFAULT_CUDA_ARCH)
+        if (NOT ARCH IN_LIST SUPPORTED_CUDA_ARCH)
+            list(REMOVE_ITEM DEFAULT_CUDA_ARCH "${ARCH}")
+        endif()
+        list(REMOVE_DUPLICATES CUDA_ARCH)
+        list(REMOVE_ITEM CUDA_ARCH "")
+        list(SORT CUDA_ARCH)
     endforeach()
 
-    # Add the last arch again as compute_, compute_ to enable forward looking JIT
-    list(GET CUDA_ARCH -1 LAST_ARCH)
-    set(GENCODES_FLAGS "${GENCODES_FLAGS} -gencode arch=compute_${LAST_ARCH},code=compute_${LAST_ARCH}")
+    if(NOT CUDA_ARCH_LENGTH EQUAL 0)
+        # Convert user provided string argument to a list.
+        string (REPLACE " " ";" CUDA_ARCH "${CUDA_ARCH}")
+        string (REPLACE "," ";" CUDA_ARCH "${CUDA_ARCH}")
 
-    # Get the minimum device architecture to pass through to nvcc to enable graceful failure prior to cuda execution.
-    list(GET CUDA_ARCH 0 MIN_CUDA_ARCH)
+        # Remove duplicates, empty items and sort.
+        list(REMOVE_DUPLICATES CUDA_ARCH)
+        list(REMOVE_ITEM CUDA_ARCH "")
+        list(SORT CUDA_ARCH)
 
-    # Set the gencode flags on NVCC
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${GENCODES_FLAGS}")
+        # Validate the list.
+        foreach(ARCH IN LISTS CUDA_ARCH)
+            if (NOT ARCH IN_LIST SUPPORTED_CUDA_ARCH)
+                message(WARNING
+                "  CUDA_ARCH '${ARCH}' not supported by CUDA ${CMAKE_CUDA_COMPILER_VERSION} and is being ignored.\n"
+                "  Choose from: ${SUPPORTED_CUDA_ARCH}")
+                list(REMOVE_ITEM CUDA_ARCH "${ARCH}")
+            endif()
+        endforeach()
+    endif()
 
-    # Set the minimum arch flags for all compilers
-    set(CMAKE_CC_FLAGS "${CMAKE_C_FLAGS} -DMIN_CUDA_ARCH=${MIN_CUDA_ARCH}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMIN_CUDA_ARCH=${MIN_CUDA_ARCH}")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DMIN_CUDA_ARCH=${MIN_CUDA_ARCH}")
-else()
-    message(STATUS "Generating default CUDA Compute Capabilities ${CUDA_ARCH}")
-endif()
 
-# Supress deprecated architecture warnings, as they are not fitered out by checking against nvcc help.
-# Ideally a warning would be output once at config time (i.e. above) and not at every file compilation.
-# But this is challenging due to multiline string detection.
-# Could potentially compile a simple program, without this flag to detect if its valid/deprecated? Would likely increase build time.
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+    # If the list is empty post validation, set it to the (validated) defaults
+    list(LENGTH CUDA_ARCH CUDA_ARCH_LENGTH)
+    if(CUDA_ARCH_LENGTH EQUAL 0)
+        set(CUDA_ARCH ${DEFAULT_CUDA_ARCH})
+    endif()
 
-# If CUDA 11.2+, can build multiple architectures in parallel. Note this will be multiplicative against the number of threads launched for parallel cmake build, which may anger some systems.
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND USE_NVCC_THREADS AND DEFINED NVCC_THREADS AND NVCC_THREADS GREATER_EQUAL 0)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --threads ${NVCC_THREADS}")
-endif()
+    # Propagate the validated values to the parent scope, to reduce warning duplication.
+    get_directory_property(hasParent PARENT_DIRECTORY)
+    if(hasParent)
+        set(CUDA_ARCH ${CUDA_ARCH} PARENT_SCOPE)
+    endif()
 
+    # If the list is somehow empty now, do not set any gencodes arguments, instead using the compiler defaults.
+    list(LENGTH CUDA_ARCH CUDA_ARCH_LENGTH)
+    if(NOT CUDA_ARCH_LENGTH EQUAL 0)
+        # Only do this if required.I.e. CUDA_ARCH is the same as the last time this file was included
+        if(NOT CUDA_ARCH_APPLIED EQUAL CUDA_ARCH)
+            message(STATUS "Generating Compute Capabilities: ${CUDA_ARCH}")
+            if(hasParent)
+                set(CUDA_ARCH_APPLIED "${CUDA_ARCH}" PARENT_SCOPE )
+            endif()
+        endif()
+        set(MIN_CUDA_ARCH)
+        # Convert to gencode arguments
+
+        foreach(ARCH IN LISTS CUDA_ARCH)
+            target_compile_options(${SCG_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_${ARCH}$<COMMA>code=sm_${ARCH}>")
+            target_link_options(${SCG_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-gencode arch=compute_${ARCH}$<COMMA>code=sm_${ARCH}>")
+        endforeach()
+
+        # Add the last arch again as compute_, compute_ to enable forward looking JIT
+        list(GET CUDA_ARCH -1 LAST_ARCH)
+        target_compile_options(${SCG_TARGET} PRIVATE  "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_${LAST_ARCH}$<COMMA>code=compute_${LAST_ARCH}>")
+        target_link_options(${SCG_TARGET} PRIVATE  "$<DEVICE_LINK:SHELL:-gencode arch=compute_${LAST_ARCH}$<COMMA>code=compute_${LAST_ARCH}>")
+
+        # Get the minimum device architecture to pass through to nvcc to enable graceful failure prior to cuda execution.
+        list(GET CUDA_ARCH 0 MIN_CUDA_ARCH)
+
+        # Set the minimum arch flags for all compilers
+        target_compile_definitions(${SCG_TARGET} PRIVATE -DMIN_CUDA_ARCH=${MIN_CUDA_ARCH})
+    else()
+        message(STATUS "Generating default CUDA Compute Capabilities ${CUDA_ARCH}")
+    endif()
+endmacro()

--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -3,22 +3,17 @@ if(NOT FLAMEGPU_CXX_STD)
     # FLAME GPU is c++14, however due to MSVC 16.10 regressions we build as 17 if possible, else 14. 
     # 14 Support is still required (CUDA 10.x, swig?).
     # Start by assuming both should be availble.
+    # No need to check CMake version, as our minimum (3.18) supports CUDA c++17
     set(CXX17_SUPPORTED ON)
-    # CMake 3.18 adds CUDA CXX 17, 20
-    # CMake 3.10 adds CUDA CXX 14
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
-        # 17 OK
-    elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
-        set(CXX17_SUPPORTED OFF)
-    else()
-        message(FATAL_ERROR "CMAKE ${CMAKE_VERSION} does not support -std=c++14")
-    endif()
+
+    # Check the CU
     # CUDA 11.0 adds CXX 17
     # CUDA 9.0 adds CXX 14
     if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.0)
         # 17 is ok.
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0)
         # 14 is ok, 17 is not.
+        # no need for an extra deprecation warning here, already warning in common about CUDA version.
         set(CXX17_SUPPORTED OFF)
     else()
         # Fatal Error.
@@ -32,11 +27,13 @@ if(NOT FLAMEGPU_CXX_STD)
         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.29)
             # 17 required.
             if(NOT CXX17_SUPPORTED)
-                message(FATAL_ERROR "MSVC >= 19.29 requires CMake >= 3.18 and CUDA >= 11.0")
+                message(FATAL_ERROR "MSVC >= 19.29 requires CUDA >= 11.0")
             endif()
         elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.11)
             # 17 available?
         elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
+            # Emit a deprecation warning for VS20XX that is not c++17 supporting. I think this is VS2017 which will be broken anyway with CUDA 
+            message(DEPRECATION "Use of MSVC ${CMAKE_CXX_COMPILER_VERSION} is deprecated. A C++17 compiler (>= 19.11) will be required in a future release.")
             set(CXX17_SUPPORTED OFF)
         else()
             message(FATAL_ERROR "MSVC ${CMAKE_CXX_COMPILER_VERSION} does not support -std=c++14")
@@ -56,6 +53,20 @@ if(NOT FLAMEGPU_CXX_STD)
     #     # Forward to the parent scope so it persists between calls.
     #     set(FLAMEGPU_CXX_STD ${FLAMEGPU_CXX_STD} PARENT_SCOPE)
     # endif()
+
+    # Emit a developer warning if using CUDA 11.0 and GCC 9 in c++17 mode re std::vector<std::tuple<...>>::push_back
+    if( CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0"
+        AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1"
+        AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9"
+        AND CMAKE_CXX_COMILER_VERSION VERSION_LESS "10"
+        AND (FLAMEGPU_CXX_STD EQUAL 17 OR CMAKE_CUDA_STANDARD EQUAL 17))
+        # https://github.com/FLAMEGPU/FLAMEGPU2/issues/650
+        message(AUTHOR_WARNING 
+            "CUDA 11.0 with g++ 9 in c++17 mode may encounter compiler segmentation faults with 'std::vector<std::tuple<...>>::push_back'.\n"
+            "Consider using CUDA 11.1+ or gcc 8 to avoid potential issues.\n"
+            "See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650 for more information.")
+    endif()
 endif()
 
 # @future - set this on a per target basis using set_target_properties?

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,110 +1,194 @@
-# Function to suppress compiler warnings for a given target
+# Function to disable all (as many as possible) compiler warnings for a given target
 function(DisableCompilerWarnings)
     # Parse the expected arguments, prefixing variables.
     cmake_parse_arguments(
-        DISABLE_COMPILER_WARNINGS
+        DCW
         ""
         "TARGET"
         ""
         ${ARGN}
     )
     # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT DISABLE_COMPILER_WARNINGS_TARGET)
-        message( FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required." )
-    elseif(NOT TARGET ${DISABLE_COMPILER_WARNINGS_TARGET} )
-        message( FATAL_ERROR "DisableCompilerWarnings: TARGET '${DISABLE_COMPILER_WARNINGS_TARGET}' is not a valid target" )
+    if(NOT DCW_TARGET)
+        message(FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required.")
+    elseif(NOT TARGET ${DCW_TARGET})
+        message(FATAL_ERROR "DisableCompilerWarnings: TARGET '${DCW_TARGET}' is not a valid target")
     endif()
     # By default, suppress all warnings, so that warnings are applied per-target.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
+        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
     else()
-        target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
+        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
     endif()
     # Always tell nvcc to disable warnings
-    target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
+    target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
 endfunction()
-# Define a function which applies warning flags to a given target.
-# Also enables the treating of warnings as errors if required.
-function(EnableCompilerWarnings)
+
+# Function to set a high level of compiler warnings for a target
+# Function to disable all (as many as possible) compiler warnings for a given target
+function(SetHighWarningLevel)
     # Parse the expected arguments, prefixing variables.
     cmake_parse_arguments(
-        ENABLE_COMPILER_WARNINGS
+        SHWL
         ""
         "TARGET"
         ""
         ${ARGN}
     )
     # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT ENABLE_COMPILER_WARNINGS_TARGET)
-        message( FATAL_ERROR "EnableCompilerWarnings: 'TARGET' argument required." )
-    elseif(NOT TARGET ${ENABLE_COMPILER_WARNINGS_TARGET} )
-        message( FATAL_ERROR "EnableCompilerWarnings: TARGET '${ENABLE_COMPILER_WARNINGS_TARGET}' is not a valid target" )
+    if(NOT SHWL_TARGET)
+        message(FATAL_ERROR "SetHighWarningLevel: 'TARGET' argument required.")
+    elseif(NOT TARGET ${SHWL_TARGET})
+        message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
     endif()
-    # Host Compiler version specific high warnings
+    
+    # Per host-compiler settings for high warning levels and opt-in warnings.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
-        # Also suppress some unwanted W4 warnings
-        # decorated name length exceeded, name was truncated
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
-        # 'function' : unreferenced local function has been removed
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
-        # unreferenced formal parameter warnings disabled - tests make use of it.
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
-        # C4127: conditional expression is constant. Longer term true static assertions would be better.
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
-        # Suppress some VS2015 specific warnings.
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
-        endif()
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
     else()
         # Assume using GCC/Clang which Wall is relatively sane for. 
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
-        # CUB 1.9.10 prevents Wreorder being usable on windows. Cannot suppress via diag_suppress pragmas.
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
+        # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
     endif()
-    # Promote warnings to errors if requested
+    # Generic options regardless of platform/host compiler:
+    # Ensure NVCC outputs warning numbers
+    target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+endfunction()
+
+# Function to apply warning suppressions to a given target, without changing the general warning level (This is so SWIG can have suppressions, with default warning levels)
+function(SuppressSomeCompilerWarnings)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        SSCW
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT SSCW_TARGET)
+        message(FATAL_ERROR "SuppressSomeCompilerWarnings: 'TARGET' argument required.")
+    elseif(NOT TARGET ${SSCW_TARGET})
+        message(FATAL_ERROR "SuppressSomeCompilerWarnings: TARGET '${SSCW_TARGET}' is not a valid target")
+    endif()
+
+    # Per host-compiler/OS settings for suppressions
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # decorated name length exceeded, name was truncated
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
+        # 'function' : unreferenced local function has been removed
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
+        # unreferenced formal parameter warnings disabled - tests make use of it.
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
+        # C4127: conditional expression is constant. Longer term true static assertions would be better.
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
+        # Suppress some VS2015 specific warnings.
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+        endif()
+        # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
+        target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
+    else()
+        # Linux specific warning suppressions
+    endif()
+    # Generic OS/host compiler warning suppressions
+    # Ensure NVCC outputs warning numbers
+    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+    # Suppress deprecated compute capability warnings.
+    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>")
+    target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:-Wno-deprecated-gpu-targets>")
+    # Supress CUDA 11.3 specific warnings, which are host compiler agnostic.
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
+        # Suppress 117-D, declared_but_not_referenced
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
+    endif()
+    # Suppress nodiscard warnings from the cuda frontend
+    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+endfunction()
+
+# Function to promote warnings to errors, controlled by the WARNINGS_AS_ERRORS CMake option.
+function(EnableWarningsAsErrors)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        EWAS
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT EWAS_TARGET)
+        message(FATAL_ERROR "EnableWarningsAsErrors: 'TARGET' argument required.")
+    elseif(NOT TARGET ${EWAS_TARGET})
+        message(FATAL_ERROR "EnableWarningsAsErrors: TARGET '${EWAS_TARGET}' is not a valid target")
+    endif()
+    
+    # Check the WARNINGS_AS_ERRORS cmake option to optionally enable this.
     if(WARNINGS_AS_ERRORS)
         # OS Specific flags
         if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
+            # Windows specific options
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
+            # Device link warnings as errors, CMake 3.18+
+            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /WX>")
         else()
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
+            # Linux specific options
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
+            # Device link warnings as errors, CMake 3.18+
+            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
+            # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
+            # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
         endif()
+        # Platform/host-compiler indifferent options:
         # Generic WError settings for nvcc
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
+        target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
         # If CUDA 10.2+, add all_warnings to the Werror option
         if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
-        endif()
-        # If not msvc, add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
-        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call >")
-        endif()
-        # If not msvc, add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
-        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder >")
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
         endif()
     endif()
-    # Ask the cuda frontend to include warnings numbers, so they can be targetted for suppression.
-    target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
-    # Suppress nodiscard warnings from the cuda frontend
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+endfunction()
+
+
+# Define a function which sets our preffered warning options for a target:
+# + A high warning level
+# + With some warnings suppressed
+# + Optionally promotes warnings to errors.
+# Also enables the treating of warnings as errors if required.
+function(EnableFLAMEGPUCompilerWarnings)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        EFCW
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT EFCW_TARGET)
+        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: 'TARGET' argument required.")
+    elseif(NOT TARGET ${EFCW_TARGET})
+        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: TARGET '${EFCW_TARGET}' is not a valid target")
     endif()
-    # Supress CUDA 11.3 specific warnings.
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
-        # Suppress 117-D, declared_but_not_referenced
-        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
-    endif()
+
+    # Enable a high level of warnings
+    SetHighWarningLevel(TARGET ${EFCW_TARGET})
+    # Suppress some warnings
+    SuppressSomeCompilerWarnings(TARGET ${EFCW_TARGET})
+    # Optionally promote warnings to errors.
+    EnableWarningsAsErrors(TARGET ${EFCW_TARGET})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Parity with main FGPU2 CMake
-cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION VERSION 3.18 FATAL_ERROR)
 
 # Find git which is a hard dependency
 find_package(Git)
@@ -20,9 +20,6 @@ if(CMAKE_CUDA_COMPILER)
     enable_language(C)
     enable_language(CXX)
     enable_language(CUDA)
-    # CUDA_ARCH is used to control the compute capabilities to build for, via cmake/cuda_arch.cmake.
-    # @todo - use the same value as the parent project if imported.
-    include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cuda_arch.cmake)
 endif()
 
 # Openg GL is required, unless doing a lint only build.
@@ -205,19 +202,23 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-# On windows, define NOMINMAX to remove the annoying defined min and max macros
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    add_compile_definitions(NOMINMAX)
-endif()
-
+# CUDA_ARCH is used to control the compute capabilities to build for, via cmake/cuda_arch.cmake.
+# @todo - use the same value as the parent project if imported.
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cuda_arch.cmake)
 # Select the C++ standard to use 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cxxstd.cmake)
+# Import function to set compiler settings for the target
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CommonCompilerSettings.cmake)
 
 # Define output
 add_library("${PROJECT_NAME}" STATIC ${VISUALISER_ALL})
 
-# Set warning flags for the target.
-EnableCompilerWarnings(TARGET "${PROJECT_NAME}")
+# Set target level warnings.
+EnableFLAMEGPUCompilerWarnings(TARGET "${PROJECT_NAME}")
+# Apply common compiler settings
+CommonCompilerSettings(TARGET "${PROJECT_NAME}")
+# Set the cuda gencodes, potentially using the user-provided CUDA_ARCH
+SetCUDAGencodes(TARGET "${PROJECT_NAME}")
 
 # Prevent fscanf warnings for msvc. 
 if (WIN32)


### PR DESCRIPTION
Includes some of the refactored CMake from FLAMEGPU/FLAMEGPU2

+ [x] Tested on Linux
+ [x] Tested on Windows