### PR TITLE
BugFix for Linux screenshots

### DIFF
--- a/src/flamegpu/visualiser/Visualiser.h
+++ b/src/flamegpu/visualiser/Visualiser.h
@@ -28,7 +28,7 @@
 
 namespace flamegpu {
 namespace visualiser {
-
+class FrameBuffer;
 template <typename T>
 struct CUDATextureBuffer;
 class SplashScreen;
@@ -365,6 +365,9 @@ class Visualiser : public ViewportExt {
     SDL_Joystick *joystick;
     SDL_JoystickID joystickInstance;
     bool gamepadConnected;
+
+    std::shared_ptr<FrameBuffer> render_buffer;
+    std::shared_ptr<FrameBuffer> screenshot_buffer;
 };
 
 }  // namespace visualiser

--- a/src/flamegpu/visualiser/multipass/FrameBuffer.cpp
+++ b/src/flamegpu/visualiser/multipass/FrameBuffer.cpp
@@ -116,7 +116,7 @@ void FrameBuffer::makeAttachment(const FBA &attachmentConfig, GLenum attachPoint
                 if (!attachmentConfig.RenderTarget()) {  // If texture is managed
                         Texture::Format fmt(attachmentConfig.PixelFormat(), attachmentConfig.InternalFormat(), 0, attachmentConfig.StorageType());  // Size is unused for our requirements, so 0 will suffice
                         renderTarget = samples
-                            ? std::dynamic_pointer_cast<RenderTarget>(Texture2D_Multisample::make(dimensions, fmt, samples, nullptr,
+                            ? std::dynamic_pointer_cast<RenderTarget>(Texture2D_Multisample::make(dimensions, fmt, samples,
                                 Texture::WRAP_CLAMP_TO_EDGE | Texture::FILTER_MAG_LINEAR | Texture::FILTER_MIN_LINEAR | Texture::DISABLE_MIPMAP))
                             : std::dynamic_pointer_cast<RenderTarget>(Texture2D::make(dimensions, fmt, nullptr,
                                 Texture::WRAP_CLAMP_TO_EDGE | Texture::FILTER_MAG_LINEAR | Texture::FILTER_MIN_LINEAR | Texture::DISABLE_MIPMAP));
@@ -191,8 +191,11 @@ bool FrameBuffer::isValid() const {
 }
 void FrameBuffer::resize(const glm::uvec2 &dims) {
     if (scale > 0) {
-        dimensions = glm::uvec2(ceil(glm::vec2(dims)*scale));
-        makeAttachments();
+        const glm::uvec2 new_dims = glm::uvec2(ceil(glm::vec2(dims) * scale));
+        if (new_dims != dimensions) {
+            dimensions = new_dims;
+            makeAttachments();
+        }
     }
 }
 bool FrameBuffer::use()  {

--- a/src/flamegpu/visualiser/multipass/FrameBufferAttachment.h
+++ b/src/flamegpu/visualiser/multipass/FrameBufferAttachment.h
@@ -129,7 +129,7 @@ class FBAFactory {
     /**
      * Defines a FBA capable of representing a RGBA color renderbuffer FBA using a default configuration
      */
-    static FrameBufferAttachment ManagedColorRenderBuffereRGBA() {
+    static FrameBufferAttachment ManagedColorRenderBufferRGBA() {
         return ManagedColorRenderBuffer(GL_RGBA);
     }
     ////////////////////////////

--- a/src/flamegpu/visualiser/texture/Texture2D_Multisample.cpp
+++ b/src/flamegpu/visualiser/texture/Texture2D_Multisample.cpp
@@ -5,7 +5,6 @@ namespace visualiser {
 
 
 const char *Texture2D_Multisample::RAW_TEXTURE_FLAG = "Texture2D_Multisample";
-
 std::shared_ptr<Texture2D_Multisample> Texture2D_Multisample::make(const glm::uvec2 &dimensions, const Texture::Format &format, const unsigned int &samples, const uint64_t &options) {
     return std::shared_ptr<Texture2D_Multisample>(new Texture2D_Multisample(dimensions, format, samples, options));
 }

--- a/src/flamegpu/visualiser/texture/Texture2D_Multisample.h
+++ b/src/flamegpu/visualiser/texture/Texture2D_Multisample.h
@@ -14,13 +14,7 @@ class Texture2D_Multisample : public Texture, public RenderTarget {
         const glm::uvec2 &dimensions,
         const Texture::Format &format,
         const unsigned int &samples,
-        const void *data = nullptr,
         const uint64_t &options = FILTER_MIN_LINEAR_MIPMAP_LINEAR | FILTER_MAG_LINEAR | WRAP_REPEAT);
-    static std::shared_ptr<Texture2D_Multisample> make(
-        const glm::uvec2 &dimensions,
-        const Texture::Format &format,
-        const unsigned int &samples,
-        const uint64_t &options);
 
     // Cant fill multi sample texture from host so don't allow copy (can be done with compute shader?)
     Texture2D_Multisample(const Texture2D_Multisample& b) = delete;


### PR DESCRIPTION
Initial work on BugFix for Linux screenshots not including occluded parts of the backbuffer.

Plan is to render the scene to a texture, which is then blit to the framebuffer.

This currently works, however multisampling is disabled, extra work is required to get that back.