### PR TITLE
CUDA 11.6

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -28,10 +28,15 @@ $CUDA_KNOWN_URLS = @{
     "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe"
     "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe"
     "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
+    "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
+    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe"
+    "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe"
+    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
 $VISUAL_STUDIO_MIN_CUDA = @{
+    "2022" = "11.6.0";
     "2019" = "10.1";
     "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
     "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2
@@ -106,15 +111,23 @@ echo "$($CUDA_PACKAGES)"
 
 # Select the download link if known, otherwise have a guess.
 $CUDA_REPO_PKG_REMOTE=""
+$CUDA_REPO_PKG_LOCAL=""
 if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
     $CUDA_REPO_PKG_REMOTE=$CUDA_KNOWN_URLS[$CUDA_VERSION_FULL]
 } else{
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
-    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
+        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+    } else {
+        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    }
 }
-$CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
-
+if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
+    $CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+} else {
+    $CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+}
 
 ## ------------
 ## Install CUDA

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -28,7 +28,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.0"
+          - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: devtoolset-8
             os: ubuntu-20.04

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.0"
+          - cuda: "11.6"
             cuda_arch: "35"
             hostcxx: gcc-8
             os: ubuntu-20.04

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -24,7 +24,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.0.3"
+          - cuda: "11.6.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,194 +1,217 @@
 # Function to disable all (as many as possible) compiler warnings for a given target
-function(DisableCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        DCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT DCW_TARGET)
-        message(FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${DCW_TARGET})
-        message(FATAL_ERROR "DisableCompilerWarnings: TARGET '${DCW_TARGET}' is not a valid target")
-    endif()
-    # By default, suppress all warnings, so that warnings are applied per-target.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
-    else()
-        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
-    endif()
-    # Always tell nvcc to disable warnings
-    target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
-endfunction()
+if(NOT COMMAND DisableCompilerWarnings)
+    function(DisableCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            DCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT DCW_TARGET)
+            message(FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${DCW_TARGET})
+            message(FATAL_ERROR "DisableCompilerWarnings: TARGET '${DCW_TARGET}' is not a valid target")
+        endif()
+        # By default, suppress all warnings, so that warnings are applied per-target.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
+        else()
+            target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
+        endif()
+        # Always tell nvcc to disable warnings
+        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
+    endfunction()
+endif()
 
 # Function to set a high level of compiler warnings for a target
 # Function to disable all (as many as possible) compiler warnings for a given target
-function(SetHighWarningLevel)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        SHWL
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT SHWL_TARGET)
-        message(FATAL_ERROR "SetHighWarningLevel: 'TARGET' argument required.")
-    elseif(NOT TARGET ${SHWL_TARGET})
-        message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
-    endif()
-    
-    # Per host-compiler settings for high warning levels and opt-in warnings.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
-    else()
-        # Assume using GCC/Clang which Wall is relatively sane for. 
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
-        # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
-    endif()
-    # Generic options regardless of platform/host compiler:
-    # Ensure NVCC outputs warning numbers
-    target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
-endfunction()
+if(NOT COMMAND SetHighWarningLevel)
+    function(SetHighWarningLevel)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            SHWL
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT SHWL_TARGET)
+            message(FATAL_ERROR "SetHighWarningLevel: 'TARGET' argument required.")
+        elseif(NOT TARGET ${SHWL_TARGET})
+            message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
+        endif()
+        
+        # Per host-compiler settings for high warning levels and opt-in warnings.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
+        else()
+            # Assume using GCC/Clang which Wall is relatively sane for. 
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
+            # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+            # Add warnings which suggest the use of override
+            # Disabled, as cpplint occasionally disagrees with gcc concerning override
+            # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wsuggest-override>")
+            # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsuggest-override>")
+        endif()
+        # Generic options regardless of platform/host compiler:
+        # Ensure NVCC outputs warning numbers
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+    endfunction()
+endif()
 
 # Function to apply warning suppressions to a given target, without changing the general warning level (This is so SWIG can have suppressions, with default warning levels)
-function(SuppressSomeCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        SSCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT SSCW_TARGET)
-        message(FATAL_ERROR "SuppressSomeCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${SSCW_TARGET})
-        message(FATAL_ERROR "SuppressSomeCompilerWarnings: TARGET '${SSCW_TARGET}' is not a valid target")
-    endif()
-
-    # Per host-compiler/OS settings for suppressions
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # decorated name length exceeded, name was truncated
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
-        # 'function' : unreferenced local function has been removed
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
-        # unreferenced formal parameter warnings disabled - tests make use of it.
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
-        # C4127: conditional expression is constant. Longer term true static assertions would be better.
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
-        # Suppress some VS2015 specific warnings.
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
-            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+if(NOT COMMAND SuppressSomeCompilerWarnings)
+    function(SuppressSomeCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            SSCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT SSCW_TARGET)
+            message(FATAL_ERROR "SuppressSomeCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${SSCW_TARGET})
+            message(FATAL_ERROR "SuppressSomeCompilerWarnings: TARGET '${SSCW_TARGET}' is not a valid target")
         endif()
-        # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
-        target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
-    else()
-        # Linux specific warning suppressions
-    endif()
-    # Generic OS/host compiler warning suppressions
-    # Ensure NVCC outputs warning numbers
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
-    # Suppress deprecated compute capability warnings.
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>")
-    target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:-Wno-deprecated-gpu-targets>")
-    # Supress CUDA 11.3 specific warnings, which are host compiler agnostic.
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
-        # Suppress 117-D, declared_but_not_referenced
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
-    endif()
-    # Suppress nodiscard warnings from the cuda frontend
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
-endfunction()
+
+        # Per host-compiler/OS settings for suppressions
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            # decorated name length exceeded, name was truncated
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
+            # 'function' : unreferenced local function has been removed
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
+            # unreferenced formal parameter warnings disabled - tests make use of it.
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
+            # C4127: conditional expression is constant. Longer term true static assertions would be better.
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
+            # Suppress some VS2015 specific warnings.
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
+                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+            endif()
+            # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
+            target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
+            # CUDA 11.6 deprecates __device__ cudaDeviceSynchronize, but does not provide an alternative.
+            # This is used in cub/thrust, and windows still emits this warning from the third party library
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.6.0)
+                target_compile_definitions(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX,CUDA>:__CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING>")
+            endif()
+        else()
+            # Linux specific warning suppressions
+        endif()
+        # Generic OS/host compiler warning suppressions
+        # Ensure NVCC outputs warning numbers
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+        # Suppress deprecated compute capability warnings.
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>")
+        target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:-Wno-deprecated-gpu-targets>")
+        # Supress CUDA 11.3 specific warnings, which are host compiler agnostic.
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
+            # Suppress 117-D, declared_but_not_referenced
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
+        endif()
+        # Suppress nodiscard warnings from the cuda frontend
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+        # Suppress Power9 + GCC >= 10 note re: ABI changes in GCC >= 5
+        # "Note: the layout of aggregates containing vectors with x-byte allignment has changed in GCC 5
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:>-Wno-psabi")
+        endif()
+    endfunction()
+endif()
 
 # Function to promote warnings to errors, controlled by the WARNINGS_AS_ERRORS CMake option.
-function(EnableWarningsAsErrors)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        EWAS
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT EWAS_TARGET)
-        message(FATAL_ERROR "EnableWarningsAsErrors: 'TARGET' argument required.")
-    elseif(NOT TARGET ${EWAS_TARGET})
-        message(FATAL_ERROR "EnableWarningsAsErrors: TARGET '${EWAS_TARGET}' is not a valid target")
-    endif()
-    
-    # Check the WARNINGS_AS_ERRORS cmake option to optionally enable this.
-    if(WARNINGS_AS_ERRORS)
-        # OS Specific flags
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            # Windows specific options
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
-            # Device link warnings as errors, CMake 3.18+
-            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /WX>")
-        else()
-            # Linux specific options
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
-            # Device link warnings as errors, CMake 3.18+
-            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
-            # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
-            # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+if(NOT COMMAND EnableWarningsAsErrors)
+    function(EnableWarningsAsErrors)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            EWAS
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT EWAS_TARGET)
+            message(FATAL_ERROR "EnableWarningsAsErrors: 'TARGET' argument required.")
+        elseif(NOT TARGET ${EWAS_TARGET})
+            message(FATAL_ERROR "EnableWarningsAsErrors: TARGET '${EWAS_TARGET}' is not a valid target")
         endif()
-        # Platform/host-compiler indifferent options:
-        # Generic WError settings for nvcc
-        target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
-        # If CUDA 10.2+, add all_warnings to the Werror option
-        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
+        
+        # Check the WARNINGS_AS_ERRORS cmake option to optionally enable this.
+        if(WARNINGS_AS_ERRORS)
+            # OS Specific flags
+            if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+                # Windows specific options
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
+                # Device link warnings as errors, CMake 3.18+
+                target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /WX>")
+            else()
+                # Linux specific options
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
+                # Device link warnings as errors, CMake 3.18+
+                target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
+                # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
+                # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+            endif()
+            # Platform/host-compiler indifferent options:
+            # Generic WError settings for nvcc
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
+            # If CUDA 10.2+, add all_warnings to the Werror option
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
+            endif()
         endif()
-    endif()
-endfunction()
-
+    endfunction()
+endif()
 
 # Define a function which sets our preffered warning options for a target:
 # + A high warning level
 # + With some warnings suppressed
 # + Optionally promotes warnings to errors.
 # Also enables the treating of warnings as errors if required.
-function(EnableFLAMEGPUCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        EFCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT EFCW_TARGET)
-        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${EFCW_TARGET})
-        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: TARGET '${EFCW_TARGET}' is not a valid target")
-    endif()
+if(NOT COMMAND EnableFLAMEGPUCompilerWarnings)
+    function(EnableFLAMEGPUCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            EFCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT EFCW_TARGET)
+            message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${EFCW_TARGET})
+            message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: TARGET '${EFCW_TARGET}' is not a valid target")
+        endif()
 
-    # Enable a high level of warnings
-    SetHighWarningLevel(TARGET ${EFCW_TARGET})
-    # Suppress some warnings
-    SuppressSomeCompilerWarnings(TARGET ${EFCW_TARGET})
-    # Optionally promote warnings to errors.
-    EnableWarningsAsErrors(TARGET ${EFCW_TARGET})
-endfunction()
+        # Enable a high level of warnings
+        SetHighWarningLevel(TARGET ${EFCW_TARGET})
+        # Suppress some warnings
+        SuppressSomeCompilerWarnings(TARGET ${EFCW_TARGET})
+        # Optionally promote warnings to errors.
+        EnableWarningsAsErrors(TARGET ${EFCW_TARGET})
+    endfunction()
+endif()


### PR DESCRIPTION
Suppresses deprecation warnings emitted by CUDA 11.6 on windows due to CUB. 

Includes CMake changes to prevent the warning related functions in the repository overwriting those in the main repository (there might be a better way of dealing with this, but not 100%).

This is required for https://github.com/FLAMEGPU/FLAMEGPU2/pull/758 to pass CI