### PR TITLE
Remove CUDA 10.x and C++14 support

### DIFF
--- a/.github/scripts/install_cuda_ubuntu.sh
+++ b/.github/scripts/install_cuda_ubuntu.sh
@@ -7,7 +7,7 @@
 # @todo - pass this in from outside the script? 
 # @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
 
-# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble pre cuda 10.
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble in older CUDA releases
 CUDA_PACKAGES_IN=(
     "cuda-compiler"
     "cuda-cudart-dev"

--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -24,14 +24,20 @@ $CUDA_KNOWN_URLS = @{
     "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
     "11.2.1" = "https://developer.download.nvidia.com/compute/cuda/11.2.1/network_installers/cuda_11.2.1_win10_network.exe";
     "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
-    "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe"
-    "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe"
-    "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe"
-    "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
-    "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
-    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe"
-    "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe"
-    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe"
+    "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
+    "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe";
+    "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe";
+    "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe";
+    "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.2/network_installers/cuda_11.4.2_win10_network.exe";
+    "11.4.3" = "https://developer.download.nvidia.com/compute/cuda/11.4.3/network_installers/cuda_11.4.3_win10_network.exe";
+    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_win10_network.exe";
+    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe";
+    "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe";
+    "11.5.2" = "https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe";
+    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe";
+    "11.6.1" = "https://developer.download.nvidia.com/compute/cuda/11.6.1/network_installers/cuda_11.6.1_windows_network.exe";
+    "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
+    "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
@@ -50,6 +56,7 @@ $CUDA_PACKAGES_IN = @(
     "curand_dev";
     "nvrtc_dev";
     "cudart";
+    "thrust";
 )
 
 
@@ -100,9 +107,11 @@ Foreach ($package in $CUDA_PACKAGES_IN) {
         $package="compiler"
     } elseif($package -eq "compiler" -and [version]$CUDA_VERSION_FULL -ge [version]"9.1") {
         $package="nvcc"
-    }
+    } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
+        # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
+        continue
+    } 
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
-
 }
 echo "$($CUDA_PACKAGES)"
 ## -----------------

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -32,10 +32,6 @@ jobs:
             cuda_arch: "35"
             hostcxx: devtoolset-8
             os: ubuntu-20.04
-          # - cuda: "10.0"
-          #   cuda_arch: "35"
-          #   hostcxx: devtoolset-7
-          #   os: ubuntu-18.04
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -24,14 +24,10 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.6"
+          - cuda: "11.7"
             cuda_arch: "35"
             hostcxx: gcc-8
             os: ubuntu-20.04
-          # - cuda: "10.0"
-          #   cuda_arch: "35"
-          #   hostcxx: gcc-7
-          #   os: ubuntu-18.04
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -24,7 +24,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.6.0"
+          - cuda: "11.7.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/README.md
+++ b/README.md
@@ -7,13 +7,10 @@ It is unlikely to be useful independently.
 ## Requirements
 
 + [CMake](https://cmake.org/download/) `>= 3.18`
-  + CMake `>= 3.15` currently works, but support will be dropped in a future release.
 + [CUDA](https://developer.nvidia.com/cuda-downloads) `>= 11.0` and a Compute Capability `>= 3.5` NVIDIA GPU.
-  + CUDA `>= 10.0` currently works, but support will be dropped in a future release.
 + C++17 capable C++ compiler (host), compatible with the installed CUDA version
   + [Microsoft Visual Studio 2019](https://visualstudio.microsoft.com/) (Windows)
-  + [make](https://www.gnu.org/software/make/) and either [GCC](https://gcc.gnu.org/) `>= 7` or [Clang](https://clang.llvm.org/) `>= 5` (Linux)
-  + Older C++ compilers which support C++14 may currently work, but support will be dropped in a future release.
+  + [make](https://www.gnu.org/software/make/) and [GCC](https://gcc.gnu.org/) `>= 8.1`
 + [git](https://git-scm.com/)
 + [SDL](https://www.libsdl.org/)
 + [GLM](http://glm.g-truc.net/) *(consistent C++/GLSL vector maths functionality)*

--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -1,60 +1,31 @@
-# Select the CXX standard to use. 
+# Select the CXX standard to use, FLAME GPU 2 is c++17 only
 if(NOT FLAMEGPU_CXX_STD)
-    # FLAME GPU is c++14, however due to MSVC 16.10 regressions we build as 17 if possible, else 14. 
-    # 14 Support is still required (CUDA 10.x, swig?).
-    # Start by assuming both should be availble.
     # No need to check CMake version, as our minimum (3.18) supports CUDA c++17
-    set(CXX17_SUPPORTED ON)
 
-    # Check the CU
-    # CUDA 11.0 adds CXX 17
-    # CUDA 9.0 adds CXX 14
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.0)
-        # 17 is ok.
-    elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0)
-        # 14 is ok, 17 is not.
-        # no need for an extra deprecation warning here, already warning in common about CUDA version.
-        set(CXX17_SUPPORTED OFF)
-    else()
+    # Check the CUDA version, CUDA 11.0 adds CXX 17 support
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.0.0)
         # Fatal Error.
-        message(FATAL_ERROR "CUDA ${CMAKE_CUDA_COMPILER_VERSION} does not support -std=c++14")
+        message(FATAL_ERROR "CUDA ${CMAKE_CUDA_COMPILER_VERSION} does not support -std=c++17")
     endif()
 
-    # VS 2019 16.10.0 breaks CXX 14 + cuda. - 1930? 19.29.30037?
-    # VS 2017 version 15.3 added /std:c++17 - 1911
-    # MSVC VS2015 Update 3 added /std:c++14 >= 1900 && < 1910? 
+    # Check MSVC version, VS 2017 version 15.3 added /std:c++17 - 1911
+    # Inside source code, __STDC_VERSION__ can be used on msvc, which will have a value such as 201710L for c++17
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.29)
-            # 17 required.
-            if(NOT CXX17_SUPPORTED)
-                message(FATAL_ERROR "MSVC >= 19.29 requires CUDA >= 11.0")
-            endif()
-        elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.11)
-            # 17 available?
-        elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
-            # Emit a deprecation warning for VS20XX that is not c++17 supporting. I think this is VS2017 which will be broken anyway with CUDA 
-            message(DEPRECATION "Use of MSVC ${CMAKE_CXX_COMPILER_VERSION} is deprecated. A C++17 compiler (>= 19.11) will be required in a future release.")
-            set(CXX17_SUPPORTED OFF)
-        else()
-            message(FATAL_ERROR "MSVC ${CMAKE_CXX_COMPILER_VERSION} does not support -std=c++14")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.11)
+            message(FATAL_ERROR "MSVC ${CMAKE_CXX_COMPILER_VERSION} does not support -std=c++17 (>= 19.11 required)")
         endif()
     endif()
 
-    # gcc supported C++17 since 5, so any version supported by cuda 10+ (no need to check, a configure time error will already occur.)
-    # Inside source code, __STDC_VERSION__ can be used on msvc, which will have a value such as 201710L for c++17
+    # GCC 8 required for <filesystem>
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.1)
+        message(FATAL_ERROR "GCC >= 8.1 required for -std=c++17 <filesystem>")
+    endif()
 
     # Set a cmake variable so this is only calcualted once, and can be applied afterwards.
-    if(CXX17_SUPPORTED)
-        set(FLAMEGPU_CXX_STD 17)
-    else()
-        set(FLAMEGPU_CXX_STD 14)
-    endif()
-    # if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    #     # Forward to the parent scope so it persists between calls.
-    #     set(FLAMEGPU_CXX_STD ${FLAMEGPU_CXX_STD} PARENT_SCOPE)
-    # endif()
+    set(FLAMEGPU_CXX_STD 17)
 
     # Emit a developer warning if using CUDA 11.0 and GCC 9 in c++17 mode re std::vector<std::tuple<...>>::push_back
+    # @todo - promote this to a try compile, and issue the (author) warning if the erorr is encountered?
     if( CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0"
         AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1"
         AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -100,11 +100,6 @@ if(NOT COMMAND SuppressSomeCompilerWarnings)
             # C4127: conditional expression is constant. Longer term true static assertions would be better.
             target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
             target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
-            # Suppress some VS2015 specific warnings.
-            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
-                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
-            endif()
             # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
             target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
             # CUDA 11.6 deprecates __device__ cudaDeviceSynchronize, but does not provide an alternative.
@@ -177,10 +172,8 @@ if(NOT COMMAND EnableWarningsAsErrors)
             # Platform/host-compiler indifferent options:
             # Generic WError settings for nvcc
             target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
-            # If CUDA 10.2+, add all_warnings to the Werror option
-            if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
-                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
-            endif()
+            # Add all_warnings to the Werror option (supported by all CUDA 11.x+)
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
         endif()
     endfunction()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,10 @@ project(flamegpu_visualiser)
 # handle cpplint.
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cpplint.cmake)
 
-# Check to see if CUDA is available.
+# Check to see if CUDA is available, and meets the required minimum version for non-lint builds
+if(NOT DEFINED MINIMUM_CUDA_VERSION)
+    set(MINIMUM_CUDA_VERSION 11.0)
+endif()
 include(CheckLanguage)
 check_language(CUDA)
 if(CMAKE_CUDA_COMPILER)
@@ -165,8 +168,8 @@ if(LINT_ONLY_BUILD)
     if (NOT OPENGL_FOUND)
         message(STATUS "OpenGL is required for building")
     endif ()
-    if (NOT CMAKE_CUDA_COMPILER)
-        message(STATUS "CUDA is required for building")
+    if (NOT CMAKE_CUDA_COMPILER OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_CUDA_VERSION})
+        message(STATUS "CUDA >= ${MINIMUM_CUDA_VERSION} is required for building")
     endif ()
     # return from the file.
     return()
@@ -176,10 +179,9 @@ endif()
 if (NOT OPENGL_FOUND)
     message(FATAL_ERROR "OpenGL is required for building")
 endif ()
-if (NOT CMAKE_CUDA_COMPILER)
-    message(FATAL_ERROR "CUDA is required for building")
+if (NOT CMAKE_CUDA_COMPILER OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_CUDA_VERSION})
+    message(FATAL_ERROR "CUDA >= ${MINIMUM_CUDA_VERSION} is required for building")
 endif ()
-
 # Include the warnings cmake file. Disabling all warning by default, and providing a mechanism to opt-in for some targets
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/warnings.cmake)
 
@@ -225,15 +227,13 @@ if (WIN32)
   target_compile_definitions("${PROJECT_NAME}" PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
 endif()
 
-# Ensure VS uses SYSTEM if available.
+# Ensure VS uses SYSTEM if available, present in 19.10+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
-        # These flags don't currently have any effect on how CMake passes system-private includes to msvc (VS 2017+)
-        set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I")
-        set(CMAKE_INCLUDE_SYSTEM_FLAG_CUDA "/external:I")
-        # VS 2017+
-        target_compile_options("${PROJECT_NAME}" PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/experimental:external>")
-    endif()
+    # These flags don't currently have any effect on how CMake passes system-private includes to msvc (VS 2017+)
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I")
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_CUDA "/external:I")
+    # VS 2017+
+    target_compile_options("${PROJECT_NAME}" PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/experimental:external>")
 endif()
 
 # Set up include dirs
@@ -263,8 +263,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 # If gcc, need to add flag for std::experimental::filesystem (for c++14 support)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries("${PROJECT_NAME}" "-lstdc++fs")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    target_link_libraries("${PROJECT_NAME}" stdc++fs)
 endif()
 
 # Strip trailiing whitespace from SDL2_Libraries for Ubuntu1604 / libsdl2-dev 2.0.4


### PR DESCRIPTION
+ Blocks CUDA 10.x
+ Always builds as c++17, implicitly increasing minimum host compiler versions
+ Use `std::filesystem` all the time

This matches with a corresponding FLAMEGPU/FLAMEGPU2 pull request, although this is not required for the main repository to still function as intended (infact, this should be merged after or as part of that PR being merged, though we do not have vis + CUDA 10 CI anyway iirc)