### PR TITLE
imgui support for bespoke interfaces

### DIFF
--- a/cmake/dependencies/imgui-CMakeLists.txt.in
+++ b/cmake/dependencies/imgui-CMakeLists.txt.in
@@ -1,0 +1,57 @@
+project(imgui LANGUAGES CXX)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # If top level project
+    SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE}/)
+else()
+    # If called via add_subdirectory()
+    SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../lib/${CMAKE_BUILD_TYPE}/)
+endif()
+
+# Glob for sources
+file(GLOB imgui_sources LIST_DIRECTORIES false ${PROJECT_SOURCE_DIR}/imgui/*.cpp ${PROJECT_SOURCE_DIR}/imgui/*.h)
+
+# Include back-end specific sources
+set(imgui_sources ${imgui_sources}
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_sdl.h
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_sdl.cpp
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_opengl3.cpp
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_opengl3.h
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_opengl3_loader.h
+)
+if(MSVC) 
+set(imgui_sources ${imgui_sources}
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_win32.h
+  ${PROJECT_SOURCE_DIR}/imgui/backends/imgui_impl_win32.cpp
+)
+endif()
+
+# Depends on the cpp and header files in case of changes
+add_library(imgui STATIC ${imgui_sources})
+
+
+# Specify the include directory, to be forwared to targets which link against the imgui target.
+# Mark this as SYSTEM INTERFACE, so that it does not result in compiler warnings being generated for dependent projects.
+# For our use  case, this is up a folder so we can use imgui/imgui.h as the include, by resolving the relative path to get an abs path
+get_filename_component(imgui_inc_dir ${imgui_SOURCE_DIR} REALPATH)
+target_include_directories("${PROJECT_NAME}" SYSTEM INTERFACE ${imgui_SOURCE_DIR}/imgui ${imgui_SOURCE_DIR})
+
+# Because we're using a nested dir rather than root, specify include path
+target_include_directories("${PROJECT_NAME}" PUBLIC ${imgui_SOURCE_DIR}/imgui)
+# Also depends on SDL for backend
+target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS})
+
+# Add some compile time definitions
+target_compile_definitions(imgui INTERFACE $<$<CONFIG:Debug>:IMGUI_DEBUG>)
+set_target_properties(imgui PROPERTIES
+    COMPILE_DEFINITIONS "IMGUI_EXPORT"
+)
+
+# Pic is sensible for any library
+set_property(TARGET imgui PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# Suppress warnigns from this target. (Not currently required)
+#include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
+#DisableCompilerWarnings(TARGET imgui)
+
+# Create an alias target for imgui to namespace it / make it more like other modern cmake 
+add_library(ImGui::ImGui ALIAS imgui)

--- a/cmake/dependencies/imgui.cmake
+++ b/cmake/dependencies/imgui.cmake
@@ -1,0 +1,39 @@
+#########
+# imgui #
+#########
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
+include(FetchContent)
+
+cmake_policy(SET CMP0079 NEW)
+
+# Change the source_dir to allow inclusion via imgui/imgui.h rather than imgui.h
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+    GIT_TAG        v1.88
+    GIT_SHALLOW    1
+    SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/imgui-src/imgui
+    GIT_PROGRESS   ON
+    # UPDATE_DISCONNECTED   ON
+)
+
+# imgui does not include anything
+
+# @todo - try finding the package first, assuming it sets system correctly when used.
+FetchContent_GetProperties(imgui)
+if(NOT imgui_POPULATED)
+    FetchContent_Populate(imgui)
+    
+    # The imgui repository does not include a CMakeLists.txt (or similar)
+    # Create our own cmake target for imgui.
+
+    # If the target does not already exist, add it.
+    # @todo - make this far more robust.
+    if(NOT TARGET imgui)
+        # make a dynamically generated CMakeLists.txt which can be add_subdirectory'd instead, so that the .vcxproj goes in a folder. Just adding a project doesn't work.        
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/imgui-CMakeLists.txt.in ${FETCHCONTENT_BASE_DIR}/imgui-src/CMakeLists.txt @ONLY)        
+        # We've now created CMakeLists.txt so we can use MakeAvailable
+        add_subdirectory(${imgui_SOURCE_DIR}/.. ${imgui_BINARY_DIR})
+    endif()
+endif()

--- a/include/flamegpu/visualiser/FLAMEGPU_Visualisation.h
+++ b/include/flamegpu/visualiser/FLAMEGPU_Visualisation.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <cstdint>
 
 #include "flamegpu/visualiser/config/TexBufferConfig.h"
 
@@ -36,10 +37,18 @@ class FLAMEGPU_Visualisation {
         updateAgentStateBuffer(agent_name.c_str(), state_name.c_str(), buffLen, core_tex_buffers, tex_buffers);
     }
     /**
+     * Provide an environment property, so it can be displayed
+     */
+    void registerEnvironmentProperty(const std::string& property_name, void* ptr, std::type_index type, unsigned int elements, bool is_const);
+    /**
      * Update the UI step counter
      * @note When this value is first set non-0, the visualiser assumes sim has begun executing
      */
     void setStepCount(const unsigned int stepCount);
+    /**
+     * Provide the random seed, so it can be displayed in the debug menu
+     */
+    void setRandomSeed(uint64_t randomSeed);
     /*
      * Start visualiser in background thread
      */

--- a/include/flamegpu/visualiser/config/ImGuiWidgets.h
+++ b/include/flamegpu/visualiser/config/ImGuiWidgets.h
@@ -1,0 +1,263 @@
+#ifndef INCLUDE_FLAMEGPU_VISUALISER_CONFIG_IMGUIWIDGETS_H_
+#define INCLUDE_FLAMEGPU_VISUALISER_CONFIG_IMGUIWIDGETS_H_
+
+#include <imgui.h>
+
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <algorithm>  // Not actually required, linter just thinks initialiser for max is fn call
+
+namespace flamegpu {
+namespace visualiser {
+
+/**
+ * Template for converting a type to the corresponding ImGui type enum
+ * Useful when summing unknown values
+ * e.g. sum_input_t<float>::result_t == double
+ * e.g. sum_input_t<uint8_t>::result_t == uint64_t
+ */
+template <typename T> struct imgui_type;
+/**
+ * @see imgui_type
+ */
+template <> struct imgui_type<char>     { static constexpr ImGuiDataType_ t = ImGuiDataType_S8;     static constexpr const char* fmt = "%c"; };
+template <> struct imgui_type<int8_t>   { static constexpr ImGuiDataType_ t = ImGuiDataType_S8;     static constexpr const char* fmt = "%hhd"; };
+template <> struct imgui_type<uint8_t>  { static constexpr ImGuiDataType_ t = ImGuiDataType_U8;     static constexpr const char* fmt = "%hhu"; };
+template <> struct imgui_type<int16_t>  { static constexpr ImGuiDataType_ t = ImGuiDataType_S16;    static constexpr const char* fmt = "%hd"; };
+template <> struct imgui_type<uint16_t> { static constexpr ImGuiDataType_ t = ImGuiDataType_U16;    static constexpr const char* fmt = "%hu"; };
+template <> struct imgui_type<int32_t>  { static constexpr ImGuiDataType_ t = ImGuiDataType_S32;    static constexpr const char* fmt = "%d"; };
+template <> struct imgui_type<uint32_t> { static constexpr ImGuiDataType_ t = ImGuiDataType_U32;    static constexpr const char* fmt = "%u"; };
+template <> struct imgui_type<int64_t>  { static constexpr ImGuiDataType_ t = ImGuiDataType_S64;    static constexpr const char* fmt = "%lld"; };
+template <> struct imgui_type<uint64_t> { static constexpr ImGuiDataType_ t = ImGuiDataType_U64;    static constexpr const char* fmt = "%llu"; };
+template <> struct imgui_type<float>    { static constexpr ImGuiDataType_ t = ImGuiDataType_Float;  static constexpr const char* fmt = "%g"; };
+template <> struct imgui_type<double>   { static constexpr ImGuiDataType_ t = ImGuiDataType_Double; static constexpr const char* fmt = "%g"; };
+
+/**
+ * The most generic abstract ImGui element superclass
+ * All other elements inherit from this
+ */
+struct PanelElement {
+    virtual ~PanelElement() = default;
+    /**
+     * Triggers the underlying call to ImGui
+     */
+    virtual bool addToImGui() = 0;
+    /**
+     * Provides copy construction behaviour
+     */
+    virtual std::unique_ptr<PanelElement> clone() const = 0;
+};
+/**
+ * Separator element, creates a horizontal line between elements
+ */
+struct SeparatorElement : PanelElement {
+    /**
+     * Constructor
+     */
+    SeparatorElement() { }
+    bool addToImGui() override { ImGui::Separator(); return false; }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new SeparatorElement()); }
+};
+/**
+ * Merely denotes that return value should be treated differently
+ */
+struct SectionElement : PanelElement { };
+/**
+ * Collapsible header element, creates a titled section which can be collapsed
+ */
+struct HeaderElement : SectionElement {
+    /**
+     * Constructor
+     * @param _text Text displayed in the section header
+     * @param _begin_open If true, the section will not begin in a collapsed state
+     */
+    explicit HeaderElement(const std::string& _text, const bool _begin_open)
+        : text(_text)
+        , begin_open(_begin_open) { }
+    bool addToImGui() override { return ImGui::CollapsingHeader(text.c_str(), begin_open ? ImGuiTreeNodeFlags_DefaultOpen : 0); }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new HeaderElement(text, begin_open)); }
+    std::string text;
+    bool begin_open;
+};
+/**
+ * Ends a section, unhiding following elements
+ */
+struct EndSectionElement : SectionElement {
+    /**
+     * Constructor
+     */
+    EndSectionElement() { }
+    bool addToImGui() override { return true; }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<EndSectionElement>(new EndSectionElement()); }
+    std::string text;
+};
+/**
+ * Label element, only contains a string used to hold it's text to be displayed
+ */
+struct LabelElement : PanelElement {
+    /**
+     * Constructor
+     * @param _text Text displayed on the label
+     */
+    explicit LabelElement(const std::string &_text)
+        : text(_text) { }
+    bool addToImGui() override { ImGui::Text("%s", text.c_str()); return false; }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new LabelElement(text)); }
+    std::string text;
+};
+/**
+ * Environment property modifier generic
+ * All environment properties inherit from this
+ */
+struct EnvPropertyElement : PanelElement {
+    /**
+     * Constructor
+     * @param _name Name of the environment property
+     * @param _index Index of the environment property element (0 if the property is not an array property)
+     * @param _ptr_offset Pointer offset from the environment property origin (as this depending on the index and type size, 0 if the property is not an array property)
+     * @note _ptr_offset should be calculated using the type information available to the subclass
+     */
+    explicit EnvPropertyElement(const std::string& _name, unsigned int _index, unsigned int _ptr_offset)
+        : data_ptr(nullptr)
+        , name(_name)
+        , index(_index)
+        , ptr_offset(_ptr_offset) { }
+    void* data_ptr;
+    std::string name;
+    unsigned int index;
+    unsigned int ptr_offset;
+    bool is_const = false;
+    bool addToImGui() override = 0;
+    std::unique_ptr<PanelElement> clone() const override = 0;
+    const std::string& getName() const { return name; }
+    void setPtr(void *ptr) { data_ptr = static_cast<char*>(ptr) + ptr_offset; }
+    void setConst(bool _is_const) { is_const = _is_const; }
+    void setArray() { name += "[" + std::to_string(index) +"]"; }
+};
+/**
+ * ImGui slider element for an environment property
+ */
+template<typename T>
+struct EnvPropertySlider : EnvPropertyElement {
+    /**
+     * Constructor
+     * @param _name Name of the environment property
+     * @param _index Index of the environment property element (0 if the property is not an array property)
+     * @param _min Minimum value of the slider
+     * @param _max Maximum value of the slider
+     */
+    EnvPropertySlider(const std::string& _name, unsigned int _index, T _min, T _max)
+        : EnvPropertyElement(_name, _index, _index * sizeof(T))
+        , min(_min)
+        , max(_max) { }
+    T min, max;
+    bool addToImGui() override {
+        if (this->data_ptr) {
+            if (this->is_const) ImGui::BeginDisabled();
+            const bool rtn = ImGui::SliderScalar(this->name.c_str(), imgui_type<T>::t, this->data_ptr, &this->min, &this->max, imgui_type<T>::fmt, ImGuiSliderFlags_AlwaysClamp);
+            if (this->is_const) ImGui::EndDisabled();
+            return rtn;
+        }
+        ImGui::Text("Loading...%s", this->name.c_str());
+        return false;
+    }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new EnvPropertySlider<T>(this->name, this->index, this->min, this->max)); }
+};
+/**
+ * ImGui drag element for an environment property
+ */
+template<typename T>
+struct EnvPropertyDrag : EnvPropertyElement {
+    /**
+     * Constructor
+     * @param _name Name of the environment property
+     * @param _index Index of the environment property element (0 if the property is not an array property)
+     * @param _min Minimum value that can be set
+     * @param _max Maximum value that can be set
+     * @param _speed Amount the value changes per pixel dragged
+     */
+    EnvPropertyDrag(const std::string& _name, unsigned int _index, T _min, T _max, float _speed)
+        : EnvPropertyElement(_name, _index, _index * sizeof(T))
+        , min(_min)
+        , max(_max)
+        , speed(_speed) { }
+    T min, max;
+    float speed;
+    bool addToImGui() override {
+        if (this->data_ptr) {
+            if (this->is_const) ImGui::BeginDisabled();
+            const bool rtn = ImGui::DragScalar(this->name.c_str(), imgui_type<T>::t, this->data_ptr, this->speed, &this->min, &this->max, imgui_type<T>::fmt, ImGuiSliderFlags_AlwaysClamp);
+            if (this->is_const) ImGui::EndDisabled();
+            return rtn;
+        }
+        ImGui::Text("Loading...%s", this->name.c_str());
+        return false;
+    }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new EnvPropertyDrag<T>(this->name, this->index, this->min, this->max, this->speed)); }
+};
+/**
+ * ImGui input with +/- step buttons for an environment property
+ */
+template<typename T>
+struct EnvPropertyInput : EnvPropertyElement {
+    /**
+     * Constructor
+     * @param _name Name of the environment property
+     * @param _index Index of the environment property element (0 if the property is not an array property)
+     * @param _step Change per button click
+     * @param _step_fast Change per tick when holding button (?)
+     */
+    EnvPropertyInput(const std::string& _name, unsigned int _index, T _step, T _step_fast)
+        : EnvPropertyElement(_name, _index, _index * sizeof(T))
+        , step(_step)
+        , step_fast(_step_fast) { }
+    T step, step_fast;
+    bool addToImGui() override {
+        if (this->data_ptr) {
+            if (this->is_const) ImGui::BeginDisabled();
+            const bool rtn = ImGui::InputScalar(this->name.c_str(), imgui_type<T>::t, this->data_ptr, &this->step, &this->step_fast, imgui_type<T>::fmt, ImGuiInputTextFlags_CallbackCompletion);
+            if (this->is_const) ImGui::EndDisabled();
+            return rtn;
+        }
+        ImGui::Text("Loading...%s", this->name.c_str());
+        return false;
+    }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new EnvPropertyInput<T>(this->name, this->index, this->step, this->step_fast)); }
+};
+/**
+ * ImGui checkbox for integer type environment properties
+ */
+template<typename T>
+struct EnvPropertyToggle : EnvPropertyElement {
+    /**
+     * Constructor
+     * @param _name Name of the environment property
+     * @param _index Index of the environment property element (0 if the property is not an array property)
+     */
+    explicit EnvPropertyToggle(const std::string& _name, unsigned int _index)
+        : EnvPropertyElement(_name, _index, _index * sizeof(T))
+        , data(false) { }
+    bool data;
+    bool addToImGui() override {
+        if (this->data_ptr) {
+            if (is_const) ImGui::BeginDisabled();
+            // How to sync data
+            if (ImGui::Checkbox(this->name.c_str(), &data)) {
+                *static_cast<T*>(data_ptr) = static_cast<T>(data ? 1 : 0);
+                return true;
+            }
+            // Really not sure that this sync will work as desired if the model updates the value independently
+            data = *static_cast<T*>(data_ptr);
+            if (is_const) ImGui::EndDisabled();
+            return false;
+        }
+        ImGui::Text("Loading...%s", this->name.c_str());
+        return false;
+    }
+    [[nodiscard]] std::unique_ptr<PanelElement> clone() const override { return std::unique_ptr<PanelElement>(new EnvPropertyToggle<T>(this->name, this->index)); }
+};
+}  // namespace visualiser
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_VISUALISER_CONFIG_IMGUIWIDGETS_H_

--- a/include/flamegpu/visualiser/config/ModelConfig.h
+++ b/include/flamegpu/visualiser/config/ModelConfig.h
@@ -3,9 +3,11 @@
 
 #include <string>
 #include <list>
+#include <map>
 #include <memory>
 
 #include "LineConfig.h"
+#include "PanelConfig.h"
 
 namespace flamegpu {
 namespace visualiser {
@@ -123,6 +125,10 @@ struct ModelConfig {
      * Store of user defined line renderings
      */
     std::list<std::shared_ptr<LineConfig>> lines;
+    /**
+     * Store of user defined UI panels
+     */
+    std::map<std::string, std::shared_ptr<PanelConfig>> panels;
     /**
      * Notify visualisation that it's running under python
      * This mostly just allows the logos to be swapped

--- a/include/flamegpu/visualiser/config/PanelConfig.h
+++ b/include/flamegpu/visualiser/config/PanelConfig.h
@@ -1,0 +1,47 @@
+#ifndef INCLUDE_FLAMEGPU_VISUALISER_CONFIG_PANELCONFIG_H_
+#define INCLUDE_FLAMEGPU_VISUALISER_CONFIG_PANELCONFIG_H_
+
+#include <list>
+#include <memory>
+#include <string>
+
+#include "ImGuiWidgets.h"
+
+namespace flamegpu {
+namespace visualiser {
+
+/**
+ * Represents the user-specified elements to be shown within an ImGui panel as part of the visualisation's UI
+ */
+struct PanelConfig {
+    /**
+     * Constructor, only a name is specified, elements can be added later
+     * @_title Name of the panel to be displayed in the title bar
+     */
+    explicit PanelConfig(const std::string &_title)
+        : title(_title) { }
+    /**
+     * Copy constructor
+     * @other Other PanelConfig to be copied
+     */
+    explicit PanelConfig(const PanelConfig& other)
+        : title(other.title) {
+        for (const auto &e : other.ui_elements) {
+            this->ui_elements.push_back(e->clone());
+        }
+    }
+    /**
+     * Name of the panel
+     * This will normally be shown in the title_bar at the top of the panel
+     */
+    std::string title;
+    /**
+     * Elements will be applied in order
+     */
+    std::list<std::unique_ptr<PanelElement>> ui_elements;
+};
+
+}  // namespace visualiser
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_VISUALISER_CONFIG_PANELCONFIG_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,10 @@ SET(VISUALISER_INCLUDE
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/AgentStateConfig.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/ModelConfig.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/LineConfig.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/PanelConfig.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/Stock.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/TexBufferConfig.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/flamegpu/visualiser/config/ImGuiWidgets.h
 )
 # Prepare list of source files
 SET(VISUALISER_SRC
@@ -107,6 +109,7 @@ SET(VISUALISER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/Texture2D_Multisample.h
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/TextureBuffer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/TextureCubeMap.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/ImGuiPanel.h
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/Overlay.h
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/SplashScreen.h
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/Sprite2D.h
@@ -140,6 +143,7 @@ SET(VISUALISER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/Texture2D_Multisample.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/TextureBuffer.cu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/texture/TextureCubeMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/ImGuiPanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/Overlay.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/SplashScreen.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/flamegpu/visualiser/ui/Sprite2D.cpp
@@ -200,6 +204,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/dependencies/fontconfig.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/dependencies/freetype.cmake)
 # DevIL
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/dependencies/devil.cmake)
+# imgui
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/dependencies/imgui.cmake)
 
 # GCC requires -lpthreads for std::thread
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
@@ -242,6 +248,7 @@ endif()
 target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${glm_INCLUDE_DIRS})
 target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS})
 target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${GLEW_INCLUDE_DIRS})
+target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${IMGUI_INCLUDE_DIRS})
 if (FREETYPE_FOUND) # Only use this if we aren't building it ourselves
     target_include_directories("${PROJECT_NAME}" SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS})
 endif ()
@@ -281,6 +288,7 @@ else()
 endif()
 target_link_libraries("${PROJECT_NAME}" freetype)
 target_link_libraries("${PROJECT_NAME}" "${IL_LIBRARIES}")
+target_link_libraries("${PROJECT_NAME}" ImGui::ImGui)
 target_link_libraries("${PROJECT_NAME}" OpenGL::GL)
 target_link_libraries("${PROJECT_NAME}" Threads::Threads)
 if(TARGET Fontconfig::Fontconfig)
@@ -361,5 +369,8 @@ if (CMAKE_USE_FOLDERS)
     endif()
     if (TARGET resources)
         set_property(TARGET "resources" PROPERTY FOLDER "FLAMEGPU/Dependencies")
+    endif()
+    if (TARGET imgui)
+        set_property(TARGET "imgui" PROPERTY FOLDER "FLAMEGPU/Dependencies")
     endif()
 endif()

--- a/src/flamegpu/visualiser/FLAMEGPU_Visualisation.cpp
+++ b/src/flamegpu/visualiser/FLAMEGPU_Visualisation.cpp
@@ -37,8 +37,14 @@ void FLAMEGPU_Visualisation::updateAgentStateBuffer(const char *agent_name, cons
     const std::map<TexBufferConfig::Function, TexBufferConfig>& core_tex_buffers, const std::multimap<TexBufferConfig::Function, CustomTexBufferConfig>& tex_buffers) {
     vis->updateAgentStateBuffer(agent_name, state_name, buffLen, core_tex_buffers, tex_buffers);
 }
+void FLAMEGPU_Visualisation::registerEnvironmentProperty(const std::string& property_name, void* ptr, const std::type_index type, const unsigned int elements, const bool is_const) {
+    vis->registerEnvironmentProperty(property_name, ptr, type, elements, is_const);
+}
 void FLAMEGPU_Visualisation::setStepCount(const unsigned int stepCount) {
     vis->setStepCount(stepCount);
+}
+void FLAMEGPU_Visualisation::setRandomSeed(const uint64_t randomSeed) {
+    vis->setRandomSeed(randomSeed);
 }
 void FLAMEGPU_Visualisation::start() {
     vis->start();

--- a/src/flamegpu/visualiser/config/ModelConfig.cpp
+++ b/src/flamegpu/visualiser/config/ModelConfig.cpp
@@ -46,6 +46,7 @@ ModelConfig &ModelConfig::operator=(const ModelConfig &other) {
     isPython = other.isPython;
     // staticModels
     // lines
+    // panels
     return *this;
 }
 

--- a/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
+++ b/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
@@ -1,0 +1,149 @@
+#include <imgui/imgui.h>
+#include <imgui/backends/imgui_impl_sdl.h>
+#include <imgui/backends/imgui_impl_opengl3.h>
+
+#include <memory>
+#include <string>
+#include <map>
+#include <cinttypes>  // for PRIu64 (cross-platform uint64_t format specifier)
+
+#include "flamegpu/visualiser/Visualiser.h"
+#include "flamegpu/visualiser/ui/ImGuiPanel.h"
+#include "flamegpu/visualiser/shader/Shaders.h"
+
+namespace flamegpu {
+namespace visualiser {
+
+ImGuiPanel::ImGuiPanel(const std::map<std::string, std::shared_ptr<PanelConfig>>& cfgs, const Visualiser& _vis)
+    : Overlay(std::make_shared<Shaders>(Stock::Shaders::SPRITE2D))
+    , vis(_vis) {
+    for (const  auto &cfg : cfgs)
+        configs.push_back(*cfg.second);
+    // Start the Dear ImGui frame
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame();  // This can't be called in the render thread, as it tries to grab the window dimensions via SDL
+}
+void ImGuiPanel::reload() {
+    first_render = 0;
+}
+void ImGuiPanel::drawPanel() {
+    const ImGuiViewport* main_viewport = ImGui::GetMainViewport();
+    ImVec2 prev_window_size(0, 0), prev_window_pos(main_viewport->WorkPos.x, main_viewport->WorkPos.y);
+    for (const auto &config : configs) {
+        // Translucent background
+        ImGui::SetNextWindowBgAlpha(150.0f / 255.0f);
+        // Size panel to fit it's content
+        ImGui::SetNextWindowSize(ImVec2(0, 0), ImGuiCond_Always);
+        if (first_render < 2) {
+            // Manual set once condition, as I can't get ImGuiCond to play nicely here for multiple panels
+            // Position multiple panels so that they don't overlap
+            ImGui::SetNextWindowPos(ImVec2(prev_window_pos.x + prev_window_size.x + 5, main_viewport->WorkPos.y + 5), ImGuiCond_Always);
+        }
+
+        // Actually start creating the panel
+        if (!ImGui::Begin(config.title.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize)) {
+            prev_window_size = ImGui::GetWindowSize();
+            prev_window_pos = ImGui::GetWindowPos();
+            // Early out if the window is collapsed, as an optimization.
+            ImGui::End();
+            return;
+        }
+
+        // Give items a fixed width (I think this i supposed to be text, but possibly conflicts with auto window resize)
+        ImGui::PushItemWidth(ImGui::GetFontSize() * 15);
+
+        // Add the user defined items in order
+        bool open = true;
+        for (auto& e : config.ui_elements) {
+            if (auto a = dynamic_cast<SectionElement*>(e.get())) {
+                open = a->addToImGui();
+            } else if (open) {
+                e->addToImGui();
+            }
+        }
+
+        // Finalise the panel
+        ImGui::PopItemWidth();
+        prev_window_size = ImGui::GetWindowSize();
+        prev_window_pos = ImGui::GetWindowPos();
+        ImGui::End();
+    }
+    first_render += first_render < 2 ? 1: 0;  // Auto size is not calculated until it's been drawn, so wait a frame to fix it
+}
+void ImGuiPanel::drawDebugPanel() const {
+    const ImGuiViewport* main_viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(ImVec2(main_viewport->WorkPos.x + 5, main_viewport->WorkPos.y + 5), ImGuiCond_Once);
+    // Translucent background
+    ImGui::SetNextWindowBgAlpha(150.0f / 255.0f);
+    // Size panel to fit it's content (might fix this width so it doesn't jump about with camera mvmt)
+    ImGui::SetNextWindowSize(ImVec2(0, 0), ImGuiCond_Always);
+
+    // Actually start creating the panel
+    ImGui::Begin("Debug Menu", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
+
+    // Give items a fixed width (I think this i supposed to be text, but possibly conflicts with auto window resize)
+    ImGui::PushItemWidth(ImGui::GetFontSize() * 15);
+
+    ImGui::Text("Initial Random Seed: %" PRIu64, vis.randomSeed);
+    const glm::vec3 eye = vis.camera->getEye();
+    const glm::vec3 look = vis.camera->getLook();
+    const glm::vec3 up = vis.camera->getUp();
+    ImGui::Text("Camera Location : (% .3f, % .3f, % .3f)", eye.x, eye.y, eye.z);
+    ImGui::Text("Camera Direction : (% .3f, % .3f, % .3f)", look.x, look.y, look.z);
+    ImGui::Text("Camera Up : (% .3f, % .3f, % .3f)", up.x, up.y, up.z);
+    ImGui::Text("MSAA: %s", (vis.msaaState ? "On" : "Off"));
+    switch (vis.fpsStatus) {
+        case 2:
+            ImGui::Text("Display FPS: Show All");
+            break;
+        case 1:
+            ImGui::Text("Display FPS: Show Step Count");
+            break;
+        default:
+            ImGui::Text("Display FPS: Off");
+    }
+    ImGui::Text("Pause Simulation: %s", (vis.pause_guard ? "On" : "Off"));
+    ImGui::Separator();
+    ImGui::Text("Agent Populations:");
+    for (const auto& as : vis.agentStates) {
+        if (vis.debugMenu_showStateNames) {
+            ImGui::BulletText("%s (%s): %u", as.first.first.c_str(), as.first.second.c_str(), as.second.requiredSize);
+        } else {
+            ImGui::BulletText("%s: %u", as.first.first.c_str(), as.second.requiredSize);
+        }
+    }
+
+    // Finalise the panel
+    ImGui::PopItemWidth();
+    ImGui::End();
+}
+void ImGuiPanel::render(const glm::mat4*, const glm::mat4*, GLuint fbo) {
+    ImGui::NewFrame();
+    // bool is_true = true;
+    // ImGui::ShowDemoWindow(&is_true);
+    if (ui_visible) drawPanel();
+    if (debug_menu_visible) drawDebugPanel();
+    // This renders the interface to a host texture
+    ImGui::Render();
+    // This presumably copies the host texture to a GPU texture and renders it
+    // imgui wants to be it's own HUD, so we kind of need to give it a full screen overlay to draw into
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    // SDL_GL_SwapWindow(window);
+}
+void ImGuiPanel::registerProperty(const std::string& name, void* ptr, bool is_const, bool is_array) {
+    for (const auto& config : configs) {
+        for (auto& e : config.ui_elements) {
+            if (auto a = dynamic_cast<EnvPropertyElement*>(e.get())) {
+                if (a->getName() == name) {
+                    if (is_const) a->setConst(true);
+                    if (is_array) a->setArray();
+                    a->setPtr(ptr);
+                }
+            }
+        }
+    }
+    first_render = 0;  // As these can change window width
+}
+
+}  // namespace visualiser
+}  // namespace flamegpu

--- a/src/flamegpu/visualiser/ui/ImGuiPanel.h
+++ b/src/flamegpu/visualiser/ui/ImGuiPanel.h
@@ -1,0 +1,94 @@
+#ifndef SRC_FLAMEGPU_VISUALISER_UI_IMGUIPANEL_H_
+#define SRC_FLAMEGPU_VISUALISER_UI_IMGUIPANEL_H_
+
+#include <memory>
+#include <string>
+#include <map>
+#include <list>
+
+#include "flamegpu/visualiser/config/PanelConfig.h"
+#include "flamegpu/visualiser/ui/Overlay.h"
+
+namespace flamegpu {
+namespace visualiser {
+
+class Visualiser;
+
+/**
+ * Class for rendering all ImGui user interfaces to the HUD
+ *
+ * ImGui draws to the whole screen space, so we handle them all at the same time for ease of input handling
+ */
+class ImGuiPanel : public Overlay {
+ public:
+    /**
+     * Default constructor, currently creates a debugging panel thing
+     * @param cfgs Map of configs specifying how they should be constructed
+     * @param _vis Handle to the visualiser so that data can be probed by the debug panel
+     */
+    explicit ImGuiPanel(const std::map<std::string, std::shared_ptr<PanelConfig>> &cfgs, const Visualiser& _vis);
+    /**
+     * Only resets first_render flag, as ImGui runs in immediate mode
+     */
+    void reload() override;
+    /**
+     * Renders the desired panels using ImGui
+     * Arguments are ignored, ImGui detects and sets these internally
+     */
+    void render(const glm::mat4*, const glm::mat4*, GLuint) override;
+    /**
+     * This must be called for every environment property stored within configs
+     * It provides the host cache pointer and constant status of each property
+     * @param name Name of the environment property
+     * @param ptr Pointer to the environment properties data within the host cache
+     * @param is_const True if the environment property should not be changed
+     * @param is_array True if the environment property's name should reflect that it's an array within the UI
+     */
+    void registerProperty(const std::string &name, void *ptr, bool is_const, bool is_array);
+    /**
+     * Toggle visibility of the debug menu
+     * @note If debug menu is made visible, the user specified panels are hidden
+     */
+    void toggleDebugMenuVisible() { debug_menu_visible = !debug_menu_visible; if (debug_menu_visible) { ui_visible = false; }}
+    /**
+     * Toggle visibility of the user specified panels
+     * @note If the user specified panels are made visible, the debug menu is hidden
+     */
+    void toggleUIVisible() { ui_visible = !ui_visible; if (ui_visible) { debug_menu_visible = false; }}
+
+ private:
+     /**
+      * If true render() triggers drawDebugPanel()
+      */
+    bool debug_menu_visible = false;
+    /**
+     * If true render() triggers drawPanel()
+     */
+    bool ui_visible = true;
+    /**
+     * Calls ImGui to draw the user specified panels from configs
+     */
+    void drawPanel();
+    /**
+     * Calls ImGui to draw the debug panel
+     */
+    void drawDebugPanel() const;
+    /**
+     * Causes panels to be automatically positioned
+     * Takes 2 frames to process, due to auto sizing
+     */
+    unsigned char first_render;
+    /**
+     * A copy of the panel configurations passed to the constructor
+     * These are maintaned as they must be passed to ImGui prior to each frame being rendered
+     */
+    std::list<PanelConfig> configs;
+    /**
+     * Used by drawDebugPanel() to access visualisation properties
+     */
+    const Visualiser &vis;
+};
+
+}  // namespace visualiser
+}  // namespace flamegpu
+#endif  // SRC_FLAMEGPU_VISUALISER_UI_IMGUIPANEL_H_

--- a/src/flamegpu/visualiser/ui/Overlay.h
+++ b/src/flamegpu/visualiser/ui/Overlay.h
@@ -43,7 +43,7 @@ class Overlay {
      * @param proj The projection matrix
      * @param fbo The buffer object holding the face indices
      */
-    void render(const glm::mat4 *mv, const glm::mat4 *proj, GLuint fbo);
+    virtual void render(const glm::mat4 *mv, const glm::mat4 *proj, GLuint fbo);
     unsigned int getWidth() const { return dimensions.x; }
     unsigned int getHeight() const { return dimensions.y;}
     std::shared_ptr<Shaders> getShaders() const { return shaders; }

--- a/src/flamegpu/visualiser/ui/Sprite2D.h
+++ b/src/flamegpu/visualiser/ui/Sprite2D.h
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "flamegpu/visualiser/texture/Texture2D.h"
-#include "Overlay.h"
+#include "flamegpu/visualiser/ui/Overlay.h"
 
 namespace flamegpu {
 namespace visualiser {


### PR DESCRIPTION
Mostly early development and testing now.

Goal is to provide support for #92
May eventually lead to deprecating internal FreeType support.

Current Progress
- [x] CMake dependency integration
    - [ ] Could improve the generated `CMakeLists.txt` by adding explicit dependency on SDL2
    - [ ] Could replace `CMakeLists.txt` glob with specific files (in future once know what we need)
- [x] Setup an interactable test UI pane
    - [x] Make ImGui mouse input not break when FullScreen is enabled
- [x] Display user specified UI
- [x] Feedback updated env properties to model 
- [x] Validate properties passed to `PanelVis`.
- [x] Read-only env prop support.
- [x] Array env props?
- [ ] Prevent race conditions?
- [x] Multi UI?
- [x] F2 to hide all UIs
- [x] Use native imgui support for all types rather than mapping
- [x] Sort out widths etc
- [x] Move debug menu to imgui (this kinda fixes where #99 was occuring)
- [ ] Allow users to specify how many dp for floating-point types
- [x] Allow a ~~button~~ checkbox for int types (although would map to 0/1)
- [x] Seperator
- [x] Comments
- [x] Documentation
- [x] ~~Update debug ui random seed if changed via HostAPI~~ Rename rng seed, to initial rng seed
- [x] Pyflamegpu
- [x] Test pyflamegpu (especially env property element)
- [x] Only allow each env prop to be in UI once (having multiple elements with same name causes input to break a bit)
- [x] Multi window no overlap?
- [x] Collapsible sections begin open?