### PR TITLE
CMake: Only look for GLEW, SDL2 & DevIL in the fetched locations on Windows

### DIFF
--- a/cmake/dependencies/devil.cmake
+++ b/cmake/dependencies/devil.cmake
@@ -27,7 +27,13 @@ elseif(WIN32)
         # Create a Cmake configuraiton file for devil (the download is not cmake aware)
         set(DevIL_DIR ${devil_SOURCE_DIR})
         configure_file(${CMAKE_CURRENT_LIST_DIR}/devil-config.cmake.in ${devil_SOURCE_DIR}/devil-config.cmake @ONLY)
-        # Find it again. Erroring if it cannot be found.
-        find_package(DevIL REQUIRED NO_MODULE)
+        # Find DevIL, only looking in the generated directory in config mode
+        find_package(DevIL REQUIRED CONFIG 
+            PATHS ${devil_SOURCE_DIR}
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
+            NO_CMAKE_PACKAGE_REGISTRY
+            NO_CMAKE_SYSTEM_PATH)
     endif()
 endif()

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -28,7 +28,13 @@ elseif(WIN32)
         # Create a Cmake configuraiton file for glew (the download is not cmake aware)
         set(GLEW_DIR ${glew_SOURCE_DIR})
         configure_file(${CMAKE_CURRENT_LIST_DIR}/glew-config.cmake.in ${glew_SOURCE_DIR}/glew-config.cmake @ONLY)
-        # Find it again. Erroring if it cannot be found.
-        find_package(GLEW REQUIRED)
+        # Just look for the fetched version of GLEW, rather than any system provided versions. Users should still be able to override this with -DGLEW_DIR=<path> ?
+        find_package(GLEW REQUIRED CONFIG 
+            PATHS ${glew_SOURCE_DIR}
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
+            NO_CMAKE_PACKAGE_REGISTRY
+            NO_CMAKE_SYSTEM_PATH)
     endif()
 endif()

--- a/cmake/dependencies/sdl2.cmake
+++ b/cmake/dependencies/sdl2.cmake
@@ -25,7 +25,13 @@ elseif(WIN32)
         # Create a Cmake configuraiton file for SDL2 (the download is not cmake aware)
         set(SDL2_DIR ${sdl2_SOURCE_DIR})
         configure_file(${CMAKE_CURRENT_LIST_DIR}/sdl2-config.cmake.in ${sdl2_SOURCE_DIR}/sdl2-config.cmake @ONLY)
-        # Find it again. Erroring if it cannot be found.
-        find_package(SDL2 REQUIRED)
+        # Find SDL2, only looking in the generated directory in config mode
+        find_package(SDL2 REQUIRED CONFIG 
+            PATHS ${sdl2_SOURCE_DIR}
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
+            NO_CMAKE_PACKAGE_REGISTRY
+            NO_CMAKE_SYSTEM_PATH)
     endif()
 endif()


### PR DESCRIPTION
 CMake: Only look for GLEW, SDL2 & DevIL in the fetched locations on Windows
    
When fetching, (fake) installing and then finding pre-compiled binary packages on windows in config mode, only look in the expected location, to avoid CMake finding an incompatible version elsewhere.


In these cases, we only want CMake to find the version we've fetched ourselves. 

Raised / tested by discussion https://github.com/FLAMEGPU/FLAMEGPU2/discussions/989

Ideally we should allow windows users to bring their own glew/SDL2/DevIL (and all other F2 dependencies), but IIRC a conda install was causing issues with that in the past (https://github.com/FLAMEGPU/FLAMEGPU2/issues/317)

---

Once merged, a PR will need to be made against FLAMEGPU/FLAMEGPU2 with the updated hash for this change to be immediately available. 