### PR TITLE
Orthographic projection mode (for 2D visualisations)

### DIFF
--- a/include/flamegpu/visualiser/config/ModelConfig.h
+++ b/include/flamegpu/visualiser/config/ModelConfig.h
@@ -134,6 +134,16 @@ struct ModelConfig {
      * This mostly just allows the logos to be swapped
      */
     bool isPython;
+    /**
+     * Use orthographic projection settings instead of perspective
+     * This is useful for 2D visualisations
+     */
+    bool isOrtho = false;
+    /**
+     * Ortho projection mode uses mousewheel to zoom
+     * This var tracks the level of zoom
+     */
+    float orthoZoom = 1.0f;
 
  private:
      /**

--- a/src/flamegpu/visualiser/Visualiser.h
+++ b/src/flamegpu/visualiser/Visualiser.h
@@ -149,6 +149,10 @@ class Visualiser : public ViewportExt {
      */
     void toggleMouseMode();
     /**
+     * Toggle between perspective and orthographic projection
+     */
+    void toggleProjection();
+    /**
      * Toggles the status of FPS logged to the HUD
      */
     void toggleFPSStatus();

--- a/src/flamegpu/visualiser/config/ModelConfig.cpp
+++ b/src/flamegpu/visualiser/config/ModelConfig.cpp
@@ -44,6 +44,8 @@ ModelConfig &ModelConfig::operator=(const ModelConfig &other) {
     stepVisible = other.stepVisible;
     beginPaused = other.beginPaused;
     isPython = other.isPython;
+    isOrtho = other.isOrtho;
+    orthoZoom = other.orthoZoom;
     // staticModels
     // lines
     // panels

--- a/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
+++ b/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
@@ -91,6 +91,10 @@ void ImGuiPanel::drawDebugPanel() const {
     ImGui::Text("Camera Location : (% .3f, % .3f, % .3f)", eye.x, eye.y, eye.z);
     ImGui::Text("Camera Direction : (% .3f, % .3f, % .3f)", look.x, look.y, look.z);
     ImGui::Text("Camera Up : (% .3f, % .3f, % .3f)", up.x, up.y, up.z);
+    ImGui::Text("Orthographic Projection: %s", (vis.modelConfig.isOrtho ? "On" : "Off"));
+    if (vis.modelConfig.isOrtho) {
+        ImGui::Text("Orthographic Zoom Mod: %.3f", vis.modelConfig.orthoZoom);
+    }
     ImGui::Text("MSAA: %s", (vis.msaaState ? "On" : "Off"));
     switch (vis.fpsStatus) {
         case 2:


### PR DESCRIPTION
It's 'zoom' is tracked independently from the perspective projection mode. Projection mode can be toggled using F9, however perspective quickly misaligns ortho from an axis. Orthographic mode zoom modifier is shown in F1 panel when enabled.

Closes #8 (We don't have support for mapping discrete agents to a texture on a single 2D plane, but this provides a great approximation for 2D models without requiring huge API changes).