### PR TITLE
Fix va_list compilation issue on arm/tegra in VisException

### DIFF
--- a/src/flamegpu/visualiser/util/VisException.cpp
+++ b/src/flamegpu/visualiser/util/VisException.cpp
@@ -31,8 +31,6 @@ void VisException::setLocation(const char *_file, const unsigned int &_line) {
 
 
 std::string VisException::parseArgs(const char * format, va_list argp) {
-    if (!argp)
-        return format;
     std::string rtn = format;
     // Create a copy of the va_list, as vsnprintf can invalidate elements of argp and find the required buffer length
     va_list argpCopy;


### PR DESCRIPTION
Remove casting of va_list to bool which does not appear to be present in gcc/glibc on ubuntu 20.04 for nvidia tegra's with GCC 9

This was previously fixed in main static lib. (See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1038)