### PR TITLE
Orthographic projection now maintains zoom level when switching to full screen

### DIFF
--- a/src/flamegpu/visualiser/Visualiser.cpp
+++ b/src/flamegpu/visualiser/Visualiser.cpp
@@ -34,9 +34,6 @@ namespace visualiser {
 #define ONE_SECOND_MS 1000
 #define VSYNC 1
 
-#define DEFAULT_WINDOW_WIDTH 1280
-#define DEFAULT_WINDOW_HEIGHT 720
-
 #define MOVEMENT_MULTIPLIER 1.f
 #define AXIS_LEFT_DEAD_ZONE 0.2f
 #define AXIS_RIGHT_DEAD_ZONE 0.15f
@@ -750,12 +747,18 @@ void Visualiser::resizeWindow() {
             modelConfig.nearFarClip[0],
             modelConfig.nearFarClip[1]);
     } else {
+        // Scale ortho zoom according to screen resolution
+        // So that zoom naturally scales with screen resolution
+        // This assures the full screen remains in frame with non uniform scaling
+        const float width_ratio = static_cast<float>(modelConfig.windowDimensions[0]) / static_cast<float>(this->windowDims.x);
+        const float height_ratio = static_cast<float>(modelConfig.windowDimensions[1]) / static_cast<float>(this->windowDims.y);
+        const float orthoZoom = modelConfig.orthoZoom * std::max<float>(width_ratio, height_ratio);
         // Ortho has no reason for near/far plane
         this->projMat = glm::ortho<float>(
-            modelConfig.orthoZoom * -static_cast<float>(this->windowDims.x) / 2.0f,
-            modelConfig.orthoZoom * static_cast<float>(this->windowDims.x) / 2.0f,
-            modelConfig.orthoZoom * -static_cast<float>(this->windowDims.y) / 2.0f,
-            modelConfig.orthoZoom * static_cast<float>(this->windowDims.y) / 2.0f,
+            orthoZoom * -static_cast<float>(this->windowDims.x) / 2.0f,
+            orthoZoom * static_cast<float>(this->windowDims.x) / 2.0f,
+            orthoZoom * -static_cast<float>(this->windowDims.y) / 2.0f,
+            orthoZoom * static_cast<float>(this->windowDims.y) / 2.0f,
             modelConfig.nearFarClip[0],
             modelConfig.nearFarClip[1]);
     }


### PR DESCRIPTION
Trivial change. I thought this needed doing before the original PR was merged, and obviously did a terrible job of checking (because I was mistaken that no additional changes were required until I started using it in Fujitsu).

Example of the automatic scaling change with resolution:

![image](https://user-images.githubusercontent.com/742154/224539681-3190337f-aab2-4c10-b8f2-6cfe8579cad9.png)
![image](https://user-images.githubusercontent.com/742154/224539699-8f33fd23-3b05-4524-b6cb-0cf744045a8e.png)
![image](https://user-images.githubusercontent.com/742154/224539691-91267fbc-33e1-43fe-b5f1-1dee87b80232.png)
![image](https://user-images.githubusercontent.com/742154/224539695-0711cc3e-6d95-49b3-8812-58169bb611fe.png)
