### PR TITLE
Step sim when paused

### DIFF
--- a/src/flamegpu/visualiser/FLAMEGPU_Visualisation.cpp
+++ b/src/flamegpu/visualiser/FLAMEGPU_Visualisation.cpp
@@ -68,7 +68,9 @@ bool FLAMEGPU_Visualisation::isReady() const {
 
 
 void FLAMEGPU_Visualisation::lockMutex() {
+    auto lock_t = new std::lock_guard<std::mutex>(vis->getRenderBufferMutexPre());
     lock = new LockHolder(vis->getRenderBufferMutex());
+    delete lock_t;
 }
 void FLAMEGPU_Visualisation::releaseMutex() {
     if (lock) {

--- a/src/flamegpu/visualiser/Visualiser.cpp
+++ b/src/flamegpu/visualiser/Visualiser.cpp
@@ -902,6 +902,16 @@ void Visualiser::handleKeypress(SDL_Keycode keycode, int /*x*/, int /*y*/) {
             stepsPerSecond = 0.0;
         }
         break;
+    case SDLK_o:
+        // If paused step the simulation, else do nothing
+        if (this->pause_guard) {
+            delete pause_guard;
+            pause_guard = nullptr;
+            const auto pause_guard_t = new std::lock_guard<std::mutex>(render_buffer_mutex_pre);
+            pause_guard = new std::lock_guard<std::mutex>(render_buffer_mutex);
+            delete pause_guard_t;
+        }
+        break;
     case SDLK_l:
         renderLines = !renderLines;
         break;

--- a/src/flamegpu/visualiser/Visualiser.cpp
+++ b/src/flamegpu/visualiser/Visualiser.cpp
@@ -335,16 +335,16 @@ void Visualiser::render() {
     }
     const float distance = speed * static_cast<float>(frameTime);
     if (!modelConfig.isOrtho) {
-        if (state[SDL_SCANCODE_W]) {
+        if (state[SDL_SCANCODE_W] || state[SDL_SCANCODE_UP]) {
             this->camera->move(distance);
         }
-        if (state[SDL_SCANCODE_A]) {
+        if (state[SDL_SCANCODE_A] || state[SDL_SCANCODE_LEFT]) {
             this->camera->strafe(-distance);
         }
-        if (state[SDL_SCANCODE_S]) {
+        if (state[SDL_SCANCODE_S] || state[SDL_SCANCODE_DOWN]) {
             this->camera->move(-distance);
         }
-        if (state[SDL_SCANCODE_D]) {
+        if (state[SDL_SCANCODE_D] || state[SDL_SCANCODE_RIGHT]) {
             this->camera->strafe(distance);
         }
         if (state[SDL_SCANCODE_Q]) {

--- a/src/flamegpu/visualiser/Visualiser.h
+++ b/src/flamegpu/visualiser/Visualiser.h
@@ -241,7 +241,13 @@ class Visualiser : public ViewportExt {
      * This must be locked before calling updateAgentStateBuffer()
      * @see updateAgentStateBuffer(const std::string &, const std::string &, const unsigned int, float *, float *, float *, float *)
      */
-    std::mutex &getRenderBufferMutex() { return render_buffer_mutex; }
+    std::mutex& getRenderBufferMutex() { return render_buffer_mutex; }
+    /**
+     * Returns the mutex for simulation stepping (for the simulation)
+     * This must be locked before locking render_buffer_mutex, then released straight after the lock is achieved
+     * @see updateAgentStateBuffer(const std::string &, const std::string &, const unsigned int, float *, float *, float *, float *)
+     */
+    std::mutex& getRenderBufferMutexPre() { return render_buffer_mutex_pre; }
     /**
      * Sets the value to be rendered to the HUD step counter (if enabled)
      * @param stepCount The step value to be displayed
@@ -381,6 +387,12 @@ class Visualiser : public ViewportExt {
      * Mutex is required to access render buffers for thread safety
      */
     std::mutex render_buffer_mutex;
+    /**
+     * Double mutex to enable simulation stepping
+     * Visualiser must lock this prior to locking render_buffer_mutex, then release this after the render_buffer_mutex lock is achieved
+     * This allows sim stepping to block a re-lock of render_buffer_mutex
+     */
+    std::mutex render_buffer_mutex_pre;
     /**
      * When this is not set to nullptr, it blocks the simulation from continuing
      */


### PR DESCRIPTION
Pressing `o` (I'm not tied to this key, its just next to `p` on the keyboard), now steps the simulation if the simulation is paused and the sim has processed it's next step.

This works with a double mutex, whereby `render_buffer_mutex_pre` is locked by the visualiser, prior to locking `render_buffer_mutex` (the normal pause mutex). After the lock of `render_buffer_mutex` is achieved, the lock on `render_buffer_mutex_pre` is released.

This allows us to quickly release the normal pause mutex, and lock `render_buffer_mutex_pre`, prior to re-locking the normal pause mutex.

This (albeit a race) should guarantee the simulation if waiting to lock the pause mutex, only has time to update the buffers and complete one step.

This approach works because, typically the simulation has completed it's next step and is waiting to update render buffers, where the pause mutex blocks it.

The downside of this approach is that it has no impact if the simulation is running slower than the time between your attempts to step the simulation (as the renderer can lock and release `render_buffer_mutex_pre` without any competition from the sim. This could be detected, by checking whether `render_buffer_mutex_pre` is already locked, and a message shared with the user.

Closes #124

First commit is a basic one, that adds alt camera controls with the arrow keys, i keep trying to use them with orthographic view.