### PR TITLE
Update vendored vector-of-bool/cmrc to 952ffdd

### DIFF
--- a/cmake/CMakeRC/CMakeRC.cmake
+++ b/cmake/CMakeRC/CMakeRC.cmake
@@ -34,7 +34,7 @@ endif()
 
 set(_version 2.0.0)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12)
 include(CMakeParseArguments)
 
 if(COMMAND cmrc_add_resource_library)
@@ -77,6 +77,10 @@ set(hpp_content [==[
 #include <system_error>
 #include <type_traits>
 
+#if !(defined(__EXCEPTIONS) || defined(__cpp_exceptions) || defined(_CPPUNWIND) || defined(CMRC_NO_EXCEPTIONS))
+#define CMRC_NO_EXCEPTIONS 1
+#endif
+
 namespace cmrc { namespace detail { struct dummy; } }
 
 #define CMRC_DECLARE(libid) \
@@ -101,7 +105,7 @@ public:
     iterator cbegin() const noexcept { return _begin; }
     iterator end() const noexcept { return _end; }
     iterator cend() const noexcept { return _end; }
-    std::size_t size() const { return std::distance(begin(), end()); }
+    std::size_t size() const { return static_cast<std::size_t>(std::distance(begin(), end())); }
 
     file() = default;
     file(iterator beg, iterator end) noexcept : _begin(beg), _end(end) {}
@@ -243,15 +247,15 @@ public:
             return !(*this == rhs);
         }
 
-        iterator operator++() noexcept {
+        iterator& operator++() noexcept {
+            ++_base_iter;
+            return *this;
+        }
+
+        iterator operator++(int) noexcept {
             auto cp = *this;
             ++_base_iter;
             return cp;
-        }
-
-        iterator& operator++(int) noexcept {
-            ++_base_iter;
-            return *this;
         }
     };
 
@@ -275,7 +279,7 @@ inline std::string normalize_path(std::string path) {
     }
     auto off = path.npos;
     while ((off = path.find("//")) != path.npos) {
-        path.erase(path.begin() + off);
+        path.erase(path.begin() + static_cast<std::string::difference_type>(off));
     }
     return path;
 }
@@ -339,7 +343,12 @@ public:
     file open(const std::string& path) const {
         auto entry_ptr = _get(path);
         if (!entry_ptr || !entry_ptr->is_file()) {
+#ifdef CMRC_NO_EXCEPTIONS
+            fprintf(stderr, "Error no such file or directory: %s\n", path.c_str());
+            abort();
+#else
             throw std::system_error(make_error_code(std::errc::no_such_file_or_directory), path);
+#endif
         }
         auto& dat = entry_ptr->as_file();
         return file{dat.begin_ptr, dat.end_ptr};
@@ -362,10 +371,20 @@ public:
     directory_iterator iterate_directory(const std::string& path) const {
         auto entry_ptr = _get(path);
         if (!entry_ptr) {
+#ifdef CMRC_NO_EXCEPTIONS
+            fprintf(stderr, "Error no such file or directory: %s\n", path.c_str());
+            abort();
+#else
             throw std::system_error(make_error_code(std::errc::no_such_file_or_directory), path);
+#endif
         }
         if (!entry_ptr->is_directory()) {
+#ifdef CMRC_NO_EXCEPTIONS
+            fprintf(stderr, "Error not a directory: %s\n", path.c_str());
+            abort();
+#else
             throw std::system_error(make_error_code(std::errc::not_a_directory), path);
+#endif
         }
         return entry_ptr->as_directory().begin();
     }
@@ -387,14 +406,14 @@ endif()
 file(GENERATE OUTPUT "${cmrc_hpp}" CONTENT "${hpp_content}" CONDITION ${_generate})
 
 add_library(cmrc-base INTERFACE)
-target_include_directories(cmrc-base INTERFACE "${CMRC_INCLUDE_DIR}")
+target_include_directories(cmrc-base INTERFACE $<BUILD_INTERFACE:${CMRC_INCLUDE_DIR}>)
 # Signal a basic C++11 feature to require C++11.
 target_compile_features(cmrc-base INTERFACE cxx_nullptr)
 set_property(TARGET cmrc-base PROPERTY INTERFACE_CXX_EXTENSIONS OFF)
 add_library(cmrc::base ALIAS cmrc-base)
 
 function(cmrc_add_resource_library name)
-    set(args ALIAS NAMESPACE)
+    set(args ALIAS NAMESPACE TYPE)
     cmake_parse_arguments(ARG "" "${args}" "" "${ARGN}")
     # Generate the identifier for the resource library's namespace
     set(ns_re "[a-zA-Z_][a-zA-Z0-9_]*")
@@ -410,6 +429,14 @@ function(cmrc_add_resource_library name)
         endif()
     endif()
     set(libname "${name}")
+    # Check that type is either "STATIC" or "OBJECT", or default to "STATIC" if
+    # not set
+    if(NOT DEFINED ARG_TYPE)
+        set(ARG_TYPE STATIC)
+    elseif(NOT "${ARG_TYPE}" MATCHES "^(STATIC|OBJECT)$")
+        message(SEND_ERROR "${ARG_TYPE} is not a valid TYPE (STATIC and OBJECT are acceptable)")
+        set(ARG_TYPE STATIC)
+    endif()
     # Generate a library with the compiled in character arrays.
     string(CONFIGURE [=[
         #include <cmrc/cmrc.hpp>
@@ -468,7 +495,7 @@ function(cmrc_add_resource_library name)
     # Generate the actual static library. Each source file is just a single file
     # with a character array compiled in containing the contents of the
     # corresponding resource file.
-    add_library(${name} STATIC ${libcpp})
+    add_library(${name} ${ARG_TYPE} ${libcpp})
     set_property(TARGET ${name} PROPERTY CMRC_LIBDIR "${libdir}")
     set_property(TARGET ${name} PROPERTY CMRC_NAMESPACE "${ARG_NAMESPACE}")
     target_link_libraries(${name} PUBLIC cmrc::base)
@@ -558,7 +585,7 @@ function(cmrc_add_resources name)
         endif()
         get_filename_component(dirpath "${ARG_PREFIX}${relpath}" DIRECTORY)
         _cmrc_register_dirs("${name}" "${dirpath}")
-        get_filename_component(abs_out "${libdir}/intermediate/${relpath}.cpp" ABSOLUTE)
+        get_filename_component(abs_out "${libdir}/intermediate/${ARG_PREFIX}${relpath}.cpp" ABSOLUTE)
         # Generate a symbol name relpath the file's character array
         _cm_encode_fpath(sym "${relpath}")
         # Get the symbol name for the parent directory

--- a/cmake/CMakeRC/README.md
+++ b/cmake/CMakeRC/README.md
@@ -39,6 +39,8 @@ required is the `CMakeRC.cmake` script. You can copy it into your project
 directory (recommended) or install it as a package and get all the features you
 need.
 
+For [vcpkg](https://github.com/microsoft/vcpkg) users there is a `cmakerc` [port](https://github.com/microsoft/vcpkg/tree/master/ports/cmakerc) that can be installed via `vcpkg install cmakerc` or by adding it to `dependencies` section of your `vcpkg.json` file.
+
 ## Usage
 
 1. Once installed, simply import the `CMakeRC.cmake` script. If you placed the


### PR DESCRIPTION
Update vendored vector-of-bool/cmrc to 952ffdd

This removes a cmake deprection notice for CMake >= 3.27, part of FLAMEGPU/FLAMEGPU2/issues/1156