### PR TITLE
CI and CMake Fixes

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -2,23 +2,23 @@
 ## Constants
 ## -------------------
 
-# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
-# From 11.0, the download URLs have changed as verisoning within CUDA has changed. 
-# The toolkit verison is separate from the individual versions of tools, i.e. toolkit 11.1.0 contains cudart 11.1.74, but CUPTI 11.1.69  
+# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern
+# From 11.0, the download url/toolkit version is separate from the cudart version.
+# Releases since 11.5.1 (including 11.4.4) use `windows` rather than `win10` in the uri, due to windows 11 inclusion
 $CUDA_KNOWN_URLS = @{
-    "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-    "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-    "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-    "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-    "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
-    "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
-    "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
-    "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
-    "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
-    "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
-    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
-    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
+    "8.0.44"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176"  = "https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85"   = "https://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148"  = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "10.0.130" = "https://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
+    "10.1.105" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
+    "10.1.168" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
+    "10.1.243" = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
+    "10.2.89"  = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+    "11.0.1" = "https://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
+    "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
+    "11.0.3" = "https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
     "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
     "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
@@ -30,7 +30,7 @@ $CUDA_KNOWN_URLS = @{
     "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe";
     "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.2/network_installers/cuda_11.4.2_win10_network.exe";
     "11.4.3" = "https://developer.download.nvidia.com/compute/cuda/11.4.3/network_installers/cuda_11.4.3_win10_network.exe";
-    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_win10_network.exe";
+    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_windows_network.exe";
     "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe";
     "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe";
     "11.5.2" = "https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe";
@@ -38,14 +38,30 @@ $CUDA_KNOWN_URLS = @{
     "11.6.1" = "https://developer.download.nvidia.com/compute/cuda/11.6.1/network_installers/cuda_11.6.1_windows_network.exe";
     "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
     "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
+    "11.7.1" = "https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe";
+    "11.8.0" = "https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe";
+    "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe";
+    "12.0.1" = "https://developer.download.nvidia.com/compute/cuda/12.0.1/network_installers/cuda_12.0.1_windows_network.exe";
+    "12.1.0" = "https://developer.download.nvidia.com/compute/cuda/12.1.0/network_installers/cuda_12.1.0_windows_network.exe";
+    "12.2.0" = "https://developer.download.nvidia.com/compute/cuda/12.2.0/network_installers/cuda_12.2.0_windows_network.exe";
+    "12.2.1" = "https://developer.download.nvidia.com/compute/cuda/12.2.1/network_installers/cuda_12.2.1_windows_network.exe";
+    "12.2.2" = "https://developer.download.nvidia.com/compute/cuda/12.2.2/network_installers/cuda_12.2.2_windows_network.exe";
+    "12.3.0" = "https://developer.download.nvidia.com/compute/cuda/12.3.0/network_installers/cuda_12.3.0_windows_network.exe";
+    "12.3.1" = "https://developer.download.nvidia.com/compute/cuda/12.3.1/network_installers/cuda_12.3.1_windows_network.exe";
+    "12.3.2" = "https://developer.download.nvidia.com/compute/cuda/12.3.2/network_installers/cuda_12.3.2_windows_network.exe";
+    "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe";
+    "12.4.1" = "https://developer.download.nvidia.com/compute/cuda/12.4.1/network_installers/cuda_12.4.1_windows_network.exe";
+    "12.5.0" = "https://developer.download.nvidia.com/compute/cuda/12.5.0/network_installers/cuda_12.5.0_windows_network.exe";
+    "12.5.1" = "https://developer.download.nvidia.com/compute/cuda/12.5.1/network_installers/cuda_12.5.1_windows_network.exe";
+    "12.6.0" = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe";
 }
 
-# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
+# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead
 $VISUAL_STUDIO_MIN_CUDA = @{
     "2022" = "11.6.0";
     "2019" = "10.1";
-    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
-    "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2
+    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on version
+    "2015" = "8.0";  # Might support older, unsure. Depracated as of 11.1, unsupported in 11.2
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
@@ -58,7 +74,6 @@ $CUDA_PACKAGES_IN = @(
     "cudart";
     "thrust";
 )
-
 
 ## -------------------
 ## Select CUDA version
@@ -110,7 +125,7 @@ Foreach ($package in $CUDA_PACKAGES_IN) {
     } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
         # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
         continue
-    } 
+    }
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
 }
 echo "$($CUDA_PACKAGES)"
@@ -127,9 +142,9 @@ if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
     if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
-        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
     } else {
-        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
     }
 }
 if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
@@ -142,7 +157,7 @@ if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
 ## Install CUDA
 ## ------------
 
-# Get CUDA network installer
+# Get CUDA network installer, retrying upto N times.
 Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
 
 $downloaded = $false
@@ -178,12 +193,12 @@ Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($C
 # Check the return status of the CUDA installer.
 if (!$?) {
     Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
-    exit 1 
+    exit 1
 }
 
 # Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
 $CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
-$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" 
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
 # Set environmental variables in this session
 $env:CUDA_PATH = "$($CUDA_PATH)"
 $env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
@@ -195,7 +210,7 @@ Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
 # Set CUDA_PATH as an environmental variable
 
 # If executing on github actions, emit the appropriate echo statements to update environment variables
-if (Test-Path "env:GITHUB_ACTIONS") { 
+if (Test-Path "env:GITHUB_ACTIONS") {
     # Set paths for subsequent steps, using $env:CUDA_PATH
     echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
     echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -52,6 +52,8 @@ jobs:
       CONFIG: ${{ matrix.config.config }}
       # Kept for portable steps between this and the main repository.
       VISUALISATION: "ON"
+      # Short term fix to use node16 not node20 for actions. This will stop working eventually, forcing our hand in dropping manylinux2014 support.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -24,7 +24,11 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.7"
+          - cuda: "12.0"
+            cuda_arch: "50"
+            hostcxx: gcc-12
+            os: ubuntu-22.04
+          - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: gcc-8
             os: ubuntu-20.04
@@ -69,7 +73,10 @@ jobs:
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}
       run: |
-        # Install ubuntu-20.04 packages
+        # Install ubuntu-22.04 packages
+        if [ "$OS" == 'ubuntu-22.04' ]; then 
+          sudo apt-get install -y libglew-dev libfontconfig1-dev libsdl2-dev libdevil-dev libfreetype-dev
+        fi
         if [ "$OS" == 'ubuntu-20.04' ]; then 
           sudo apt-get install -y libglew-dev libfontconfig1-dev libsdl2-dev libdevil-dev libfreetype-dev
         fi

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -24,7 +24,11 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.7.0"
+          - cuda: "12.0.0"
+            cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          - cuda: "11.2.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
@@ -48,6 +52,8 @@ jobs:
       CONFIG: ${{ matrix.config.config }}
       # Kept for portable steps between this and the main repository.
       VISUALISATION: "ON"
+      # Ensure MSVC >= 1940 works with CUDA <= 12.3
+      CUDAFLAGS: -allow-unsupported-compiler
 
     steps:
     - uses: actions/checkout@v3

--- a/cmake/CheckCompilerFunctionality.cmake
+++ b/cmake/CheckCompilerFunctionality.cmake
@@ -20,7 +20,34 @@ function(flamegpu_visualiser_check_compiler_functionality)
     enable_language(CXX)
     check_language(CUDA)
     if(NOT CMAKE_CUDA_COMPILER)
-        message(WARNING "CUDA Language Support Not Found")
+        # If using MSVC >= 1940 then CUDA <= 12.3 support requires -allow-unsupported-compiler, so warn about this
+        if(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL "1940")
+            # If this is the case, then CMake >= 3.29.4 is also required, otherwise CMake does not pass -allow-unsupported-compiler along, warn as appropriate
+            if(CMAKE_VERSION VERSION_LESS "3.29.4")
+                message(WARNING
+                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940)\n"
+                    " \n"
+                    " If you have CUDA <= 12.3 installed:\n"
+                    "  - You must upgrade CMake to be >= 3.29.4\n"
+                    "    The CUDAFLAGS environment variable must include '-allow-unsupported-compiler'\n"
+                    "    You must clear the CMake Cache before reconfiguring this project\n"
+                    " \n"
+                    "  - Alternatively you may upgrade CUDA to >= 12.4 and clear the CMake Cache before reconfiguring\n"
+                )
+            else()
+                message(WARNING
+                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940)\n"
+                    " \n"
+                    " If you have CUDA <= 12.3 installed:\n"
+                    "  - The CUDAFLAGS environment variable must include '-allow-unsupported-compiler'\n"
+                    "    You must clear the CMake Cache before reconfiguring this project\n"
+                    " \n"
+                    "  - Alternatively you may upgrade CUDA to >= 12.4 and clear the CMake Cache before reconfiguring\n"
+                )
+            endif()
+        else()
+            message(WARNING "CUDA Language Support Not Found")
+        endif()
         set(FLAMEGPU_VISUALISER_CheckCompilerFunctionality_RESULT "NO" PARENT_SCOPE)
         return()
     endif()

--- a/cmake/dependencies/devil.cmake
+++ b/cmake/dependencies/devil.cmake
@@ -8,10 +8,14 @@ if(UNIX)
                         "e.g. sudo apt install libdevil-dev")
     endif()
 elseif(WIN32)
-
+    include(FetchContent)
     # As the URL method is used for download, set the policy if available
     if(POLICY CMP0135)
-    cmake_policy(SET CMP0135 NEW)
+        cmake_policy(SET CMP0135 NEW)
+    endif()
+    # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
     endif()
 
     # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -10,9 +10,14 @@ if(UNIX)
                             "e.g. sudo apt install libglew-dev")
     endif ()
 elseif(WIN32)
+    include(FetchContent)
     # As the URL method is used for download, set the policy if available
     if(POLICY CMP0135)
         cmake_policy(SET CMP0135 NEW)
+    endif()
+    # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
     endif()
     # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
     # Declare source properties

--- a/cmake/dependencies/glm.cmake
+++ b/cmake/dependencies/glm.cmake
@@ -2,9 +2,14 @@
 # glm #
 #######
 
+include(FetchContent)
 # As the URL method is used for download, set the policy if available
 if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})

--- a/cmake/dependencies/imgui.cmake
+++ b/cmake/dependencies/imgui.cmake
@@ -4,9 +4,15 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-
 cmake_policy(SET CMP0079 NEW)
-
+# As the URL method is used for download, set the policy if available
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
 # Change the source_dir to allow inclusion via imgui/imgui.h rather than imgui.h
 FetchContent_Declare(
     imgui

--- a/cmake/dependencies/sdl2.cmake
+++ b/cmake/dependencies/sdl2.cmake
@@ -25,8 +25,14 @@ elseif(WIN32)
     # On windows, always download manually. There are issues with find_package and multi-config generators where a release library will be found, but no debug library, which can break things.
     # Declare source properties
     # As the URL method is used for download, set the policy if available
+    include(FetchContent)
+    # As the URL method is used for download, set the policy if available
     if(POLICY CMP0135)
         cmake_policy(SET CMP0135 NEW)
+    endif()
+    # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
     endif()
     FetchContent_Declare(
         SDL2


### PR DESCRIPTION
CI and CMake fixes caused by updated dependencies (MSVC 1940, CMake 3.30, Github Actions Node 20)

+ Short term CMake FetchContent_Populate deprecation error fix
+ Update CUDA versions in CI
+ Short term fix for GLIBC error in manylinux 2014 CI - this will need replacing with Manylinux 2_28 as part of https://github.com/FLAMEGPU/FLAMEGPU2/issues/1224
+ CI fix and useful warning for MSVC >= 1940 and CUDA <= 12.3 incompatibilty
+ Some general tidying / standardisation with the parent repo where code could be reused.