### PR TITLE
VS2022 17.11 / MSVC 1941 CI  Fix 

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -24,10 +24,16 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "12.0.0"
+          # VS2022 must now use CUDA 12.4 or newer
+          - cuda: "12.4.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
+          # VS 2019 for 11.0-12.3
+          - cuda: "12.0.0"
+            cuda_arch: "50"
+            hostcxx: "Visual Studio 16 2019"
+            os: windows-2019
           - cuda: "11.2.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"

--- a/cmake/CheckCompilerFunctionality.cmake
+++ b/cmake/CheckCompilerFunctionality.cmake
@@ -20,8 +20,20 @@ function(flamegpu_visualiser_check_compiler_functionality)
     enable_language(CXX)
     check_language(CUDA)
     if(NOT CMAKE_CUDA_COMPILER)
+        # MSVC 1941 (VS2022 17.11) requires CUDA 12.4 or greater - see https://github.com/microsoft/STL/pull/4475
+        if(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL "1941")
+            message(WARNING
+                " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1941)\n"
+                " \n"
+                " The MSVC STL included with MSVC 1941 requires CUDA 12.4 or newer\n"
+                " If you have CUDA <= 12.3 installed you must either:\n"
+                "  - Upgrade CUDA to >= 12.4\n"
+                "  - Downgrade MSVC to 1940 and set the CUDAFLAGS environment variable to contain '-allow-unsupported-compiler'\n"
+                "  - Downgrade MSVC to 1939 or older\n"
+                " You must then clear the CMake cache before reconfiguring\n"
+            )
         # If using MSVC >= 1940 then CUDA <= 12.3 support requires -allow-unsupported-compiler, so warn about this
-        if(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL "1940")
+        elseif(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL "1940")
             # If this is the case, then CMake >= 3.29.4 is also required, otherwise CMake does not pass -allow-unsupported-compiler along, warn as appropriate
             if(CMAKE_VERSION VERSION_LESS "3.29.4")
                 message(WARNING

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,9 @@ project(flamegpu_visualiser LANGUAGES NONE)
 # handle cpplint.
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/cpplint.cmake)
 
+# Ensure found compilers are actually good enough / don't trigger known issues.
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckCompilerFunctionality.cmake)
+
 # Check to see if CUDA is available, and meets the required minimum version for non-lint builds
 if(NOT DEFINED MINIMUM_CUDA_VERSION)
     set(MINIMUM_CUDA_VERSION 11.0)


### PR DESCRIPTION
VS2022 17.11 / MSVC 19.41 include a stdlib change which enforces CUDA >= 12.4 in a static assert (which I can't find a way to ignore during CMake language detection).

This Adds a new warning if this is why cuda hasn't been found, ensures the warning is triggered, and updates CI to not use VS2022 with CUDA < 12.4