### PR TITLE
Fix memory leaks

### DIFF
--- a/src/flamegpu/visualiser/Entity.cpp
+++ b/src/flamegpu/visualiser/Entity.cpp
@@ -146,6 +146,7 @@ Entity::Entity(
     , materialBuffer(std::make_shared<UniformBuffer>(sizeof(MaterialProperties) * MAX_OBJ_MATERIALS))
     , location(0.0f)
     , rotation(0.0f, 0.0f, 1.0f, 0.0f)
+    , needsExport(false)
     , cullFace(true) {
     GL_CHECK();
     loadModelFromFile();

--- a/src/flamegpu/visualiser/HUD.cpp
+++ b/src/flamegpu/visualiser/HUD.cpp
@@ -153,6 +153,12 @@ HUD::Item::Item(std::shared_ptr<Overlay> overlay, const glm::ivec2 &offset, cons
     GL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, 4*sizeof(int), &faces, GL_STATIC_DRAW));
     GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
 }
+HUD::Item::~Item() {
+    if (data) {
+        free(data);
+        data = nullptr;
+    }
+}
 void HUD::Item::resizeWindow(const glm::uvec2 &dims) {
     // Track parameters, so when called from overlay we can reuse previous
     static glm::uvec2 _dims;

--- a/src/flamegpu/visualiser/HUD.h
+++ b/src/flamegpu/visualiser/HUD.h
@@ -51,6 +51,10 @@ class HUD {
          */
         Item(std::shared_ptr<Overlay> overlay, const glm::ivec2 &offset, const glm::uvec2 &windowDims, AnchorV anchorV = AnchorV::Center, AnchorH anchorH = AnchorH::Center, const int &zIndex = 0);
         /**
+         * Destructor to free manually allocated memory
+         */
+        ~Item();
+        /**
          * Convenience resizeWindow(const glm::uvec2 &)
          * @param w The new window width
          * @param h The new window height

--- a/src/flamegpu/visualiser/Visualiser.cpp
+++ b/src/flamegpu/visualiser/Visualiser.cpp
@@ -28,6 +28,10 @@
 #include "flamegpu/visualiser/multipass/FrameBufferAttachment.h"
 #include "util/Resources.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#include <fontconfig/fontconfig.h>
+#endif
+
 namespace flamegpu {
 namespace visualiser {
 
@@ -226,6 +230,10 @@ Visualiser::Visualiser(const ModelConfig& modelcfg)
 }
 Visualiser::~Visualiser() {
     this->close();
+#if defined(__GNUC__) || defined(__clang__)
+    // Fully clean up font config
+    FcFini();
+#endif
 }
 void Visualiser::start() {
     // Only execute if background thread is not active

--- a/src/flamegpu/visualiser/texture/TextureBuffer.h
+++ b/src/flamegpu/visualiser/texture/TextureBuffer.h
@@ -5,7 +5,7 @@
 #include "Texture.h"
 
 #ifdef __CUDACC__
-#include "flamegpu/visualiser/util/cuda.cuh"
+#include "flamegpu/visualiser/util/cuda.h"
 #endif
 
 namespace flamegpu {

--- a/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
+++ b/src/flamegpu/visualiser/ui/ImGuiPanel.cpp
@@ -16,6 +16,7 @@ namespace visualiser {
 
 ImGuiPanel::ImGuiPanel(const std::map<std::string, std::shared_ptr<PanelConfig>>& cfgs, const Visualiser& _vis)
     : Overlay(std::make_shared<Shaders>(Stock::Shaders::SPRITE2D))
+    , first_render(0)
     , vis(_vis) {
     for (const  auto &cfg : cfgs)
         configs.push_back(*cfg.second);

--- a/src/flamegpu/visualiser/ui/Text.cpp
+++ b/src/flamegpu/visualiser/ui/Text.cpp
@@ -376,8 +376,14 @@ Text::TextureString::TextureString()
 }
 void Text::TextureString::resize(const glm::uvec2 &_dimensions) {
     this->dimensions = _dimensions;
-    if (texture)
+    if (texture) {
+        if (texture[0]) {
+            free(texture[0]);
+            texture[0] = nullptr;
+        }
         free(texture);
+        texture = nullptr;
+    }
     texture = reinterpret_cast<unsigned char**>(malloc(sizeof(char*) * this->dimensions.y));
     texture[0] = reinterpret_cast<unsigned char*>(malloc(sizeof(char) * this->dimensions.x * this->dimensions.y));
     memset(texture[0], 0, sizeof(char)*this->dimensions.x*this->dimensions.y);

--- a/src/flamegpu/visualiser/ui/Text.cpp
+++ b/src/flamegpu/visualiser/ui/Text.cpp
@@ -348,8 +348,10 @@ glm::vec4 Text::getBackgroundColor() const {
     return backgroundColor;
 }
 void Text::setString(const char* format, ...) {
-    if (this->string)
-        delete this->string;
+    if (this->string) {
+        free(this->string);
+        this->string = nullptr;
+    }
     // Create a copy of the va_list, as vsnprintf can invalidate elements of argp and find the required buffer length
     va_list argp;
     va_start(argp, format);

--- a/src/flamegpu/visualiser/util/fonts.cpp
+++ b/src/flamegpu/visualiser/util/fonts.cpp
@@ -94,9 +94,6 @@ std::string fontSearch(const std::string commaSeparatedfonts) {
     FcConfigDestroy(config);
     config = nullptr;
 
-    // Fully clean up font config - this should probably be in a called-once function rather than on each invocation
-    FcFini();
-
     // Return the path to the desired font.
     return fontpath;
 }

--- a/src/flamegpu/visualiser/util/fonts.cpp
+++ b/src/flamegpu/visualiser/util/fonts.cpp
@@ -94,6 +94,9 @@ std::string fontSearch(const std::string commaSeparatedfonts) {
     FcConfigDestroy(config);
     config = nullptr;
 
+    // Fully clean up font config - this should probably be in a called-once function rather than on each invocation
+    FcFini();
+
     // Return the path to the desired font.
     return fontpath;
 }

--- a/src/flamegpu/visualiser/util/fonts.cpp
+++ b/src/flamegpu/visualiser/util/fonts.cpp
@@ -90,6 +90,10 @@ std::string fontSearch(const std::string commaSeparatedfonts) {
     // Tidy up.
     FcPatternDestroy(pat);
 
+    // Destroy the FcConfig - this will force a re-initialisation on subsequent calls to fontSearch, but prevent leakage
+    FcConfigDestroy(config);
+    config = nullptr;
+
     // Return the path to the desired font.
     return fontpath;
 }


### PR DESCRIPTION
Fixes memory leaks in the visualiser, originally identified by @DavidFletcherShef in https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/issues/148. 

- [x] Delete/malloc mismatch in `Text::setString`
- [x] Missing `free` in `Text::textureString::resize`
- [x] Ensure `FcConfigDestroy` is called
  - This is a more eager than it could be
- [x] Call `FcFini` in `~Visualiser`
- [x] Add a dtor for `HUD::Item` for a missing `free`
- [x] Fix an incorrect include path in `TextureBuffer.h` (which never gets triggered anyway)
- [x] Manually free CUDATextureBuffers in `Visualiser::close`
- [x] Initialise `Entity::needsExport` to false (matching debug build behaviour)
- [x] Initialise `ImGuiPanel::first_render` to `0`
- [x] Opened issues for future enhancements identified during this PR (#150, #151)
